### PR TITLE
Development

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,7 +2,9 @@
   "permissions": {
     "allow": [
       "Bash(python3 -c ' *)",
-      "Bash(node -e \"const bp = require\\('./output/blueprint/website-blueprint.v1.json'\\); console.log\\(JSON.stringify\\(bp.ux.heroStyle, null, 2\\)\\);\")"
+      "Bash(node -e \"const bp = require\\('./output/blueprint/website-blueprint.v1.json'\\); console.log\\(JSON.stringify\\(bp.ux.heroStyle, null, 2\\)\\);\")",
+      "WebSearch",
+      "WebFetch(domain:raw.githubusercontent.com)"
     ]
   }
 }

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,13 @@
+# Google Stitch API Key
+# Required for AI-powered site generation via Google Stitch MCP
+# Get your key at: https://stitch.google.com (sign in → API Keys)
+STITCH_API_KEY=your-stitch-api-key-here
+
+# Optional: Stitch model — GEMINI_3_PRO (default, higher quality) or GEMINI_3_FLASH (faster)
+# STITCH_MODEL=GEMINI_3_PRO
+
+# ────────────────────────────────────────────────────────────────
+
 # OpenAI API Key
 # Required for AI-powered agent stages (intake, UX, SEO, accessibility, frontend)
 # Get your key at: https://platform.openai.com/api-keys

--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,8 @@ output/generated-site/**
 !output/generated-site/.gitkeep
 output/static-site/**
 !output/static-site/.gitkeep
+output/stitch-site/**
+!output/stitch-site/.gitkeep
 output/reports/*.md
 output/reports/*.json
 !output/reports/.gitkeep

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,64 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+npm run stitchfy                              # Run full agent pipeline on input/project.md
+npm run stitchfy -- --input path/to/file.md  # Run pipeline on a specific input file
+npm run build:site                            # Generate Next.js app + export to output/static-site/
+npm run build:site -- --blueprint path/to/blueprint.json
+npm run audit                                 # HTML accessibility + SEO audit → output/reports/
+npm run validate                              # Validate input file and last generated blueprint
+npm run typecheck                             # TypeScript check without emitting
+```
+
+There is no test suite. `npm run typecheck` is the primary correctness gate before submitting changes.
+
+## Architecture
+
+Stitchfy is a CLI framework: one Markdown file in → one static website out. There is no web server, no database, and no runtime.
+
+### Pipeline flow
+
+```
+input/project.md
+  → markdown-parser.ts       (ParsedMarkdown)
+  → orchestrator.ts          (drives 5 agents sequentially via agent-runner.ts)
+  → [intake → ux → seo → accessibility → frontend agents]
+  → blueprint.schema.ts      (Zod validation)
+  → blueprint-writer.ts      (output/blueprint/website-blueprint.v1.json)
+  → site-generator.ts        (output/generated-site/ — full Next.js 14 app)
+  → Next.js export           (output/static-site/ — deployable HTML/CSS/JS)
+```
+
+### Key structural rules
+
+- **`framework/schemas/blueprint.types.ts`** is the single source of truth for all TypeScript interfaces. The Zod schema in `framework/schemas/blueprint.schema.ts` must stay in sync with it.
+- Each agent in `framework/agents/` receives the `WorkflowState` and returns a partial `WebsiteBlueprint` slice. The orchestrator merges slices via spread: `state.blueprint = { ...state.blueprint, ...output }`.
+- **`site-template/`** is the template layer. `site-generator.ts` copies these components into every generated site and injects brand data. Components added to `site-template/components/` are picked up automatically.
+- All five agents contain a commented-out OpenAI API call block marked `// OPENAI INTEGRATION POINT:`. In default mode they run deterministically with no API key. The Zod validation runs regardless of mode.
+
+### Adding a new agent
+
+1. Create `framework/agents/myagent.agent.ts` implementing the `AgentConfig` interface from `framework/orchestrator/agent-runner.ts`
+2. Add the agent to the `PIPELINE` array in `framework/orchestrator/orchestrator.ts`
+3. Add any new blueprint fields to `framework/schemas/blueprint.types.ts` first, then update `framework/schemas/blueprint.schema.ts`
+
+### Output directories (all gitignored)
+
+| Path | Contents |
+|---|---|
+| `output/blueprint/` | `website-blueprint.v1.json` — validated spec |
+| `output/generated-site/` | Next.js 14 App Router source |
+| `output/static-site/` | Pure HTML/CSS/JS, deploy this folder |
+| `output/reports/` | `accessibility-report.html`, `seo-report.html`, `final-report.html` |
+
+### OpenAI integration
+
+Add `OPENAI_API_KEY=sk-...` to a `.env` file, then replace the deterministic logic in each agent with the commented API call. Default model is `gpt-4o` (via `process.env.OPENAI_MODEL`).
+
+### Industry-aware defaults
+
+The UX and SEO agents key off industry keywords (`beauty`, `wellness`, `medical`, `restaurant`) to choose Schema.org type, color palette style, and gallery seeds. Unrecognized industries fall back to `LocalBusiness` / neutral blue-grey.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,8 +7,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ```bash
 npm run stitchfy                              # Run full agent pipeline on input/project.md
 npm run stitchfy -- --input path/to/file.md  # Run pipeline on a specific input file
-npm run build:site                            # Generate Next.js app + export to output/static-site/
+npm run build:site                            # Template generator → output/static-site/
 npm run build:site -- --blueprint path/to/blueprint.json
+npm run build:site:stitch                     # Stitch MCP generator → output/stitch-site/
 npm run audit                                 # HTML accessibility + SEO audit → output/reports/
 npm run validate                              # Validate input file and last generated blueprint
 npm run typecheck                             # TypeScript check without emitting
@@ -16,11 +17,13 @@ npm run typecheck                             # TypeScript check without emittin
 
 There is no test suite. `npm run typecheck` is the primary correctness gate before submitting changes.
 
+`build:site:stitch` requires `STITCH_API_KEY` in `.env`. Optional: `STITCH_MODEL` (`GEMINI_3_1_PRO` default, or `GEMINI_3_FLASH`).
+
 ## Architecture
 
 Stitchfy is a CLI framework: one Markdown file in → one static website out. There is no web server, no database, and no runtime.
 
-### Pipeline flow
+### Pipeline flow — blueprint (shared)
 
 ```
 input/project.md
@@ -29,31 +32,58 @@ input/project.md
   → [intake → ux → seo → accessibility → frontend agents]
   → blueprint.schema.ts      (Zod validation)
   → blueprint-writer.ts      (output/blueprint/website-blueprint.v1.json)
+```
+
+### Pipeline flow — template generator (`build:site`)
+
+```
+website-blueprint.v1.json
   → site-generator.ts        (output/generated-site/ — full Next.js 14 app)
   → Next.js export           (output/static-site/ — deployable HTML/CSS/JS)
+```
+
+### Pipeline flow — Stitch generator (`build:site:stitch`)
+
+```
+website-blueprint.v1.json
+  → stitch-client.ts         (create_project → generate_screen_from_text per page → get_screen)
+  → stitch-post-processor.ts (inject SEO meta, skip link, lang, JSON-LD)
+  → stitch-seo.agent.ts      (review SEO → patches + findings)
+  → stitch-a11y.agent.ts     (review A11y → patches + findings)
+  → stitch-patcher.ts        (apply all attribute-level patches)
+  → output/stitch-site/      (deployable HTML/CSS/JS)
+  → stitch-review-reporter.ts → output/reports/stitch-review-report.html
 ```
 
 ### Key structural rules
 
 - **`framework/schemas/blueprint.types.ts`** is the single source of truth for all TypeScript interfaces. The Zod schema in `framework/schemas/blueprint.schema.ts` must stay in sync with it.
-- Each agent in `framework/agents/` receives the `WorkflowState` and returns a partial `WebsiteBlueprint` slice. The orchestrator merges slices via spread: `state.blueprint = { ...state.blueprint, ...output }`.
+- Each blueprint agent in `framework/agents/` receives the `WorkflowState` and returns a partial `WebsiteBlueprint` slice. The orchestrator merges slices via spread: `state.blueprint = { ...state.blueprint, ...output }`.
 - **`site-template/`** is the template layer. `site-generator.ts` copies these components into every generated site and injects brand data. Components added to `site-template/components/` are picked up automatically.
-- All five agents contain a commented-out OpenAI API call block marked `// OPENAI INTEGRATION POINT:`. In default mode they run deterministically with no API key. The Zod validation runs regardless of mode.
+- All five blueprint agents contain a commented-out OpenAI API call block marked `// OPENAI INTEGRATION POINT:`. In default mode they run deterministically with no API key. The Zod validation runs regardless of mode.
+- **Stitch review agents** (`stitch-seo.agent.ts`, `stitch-a11y.agent.ts`) implement a different interface than blueprint agents. They receive `(html, page, blueprint)` and return `HtmlReviewResult` from `stitch-html-review.types.ts`. Patches must be **attribute-level only** — no structural DOM changes.
+- **`stitch-client.ts`** uses JSON-RPC 2.0 over HTTP POST to `https://stitch.googleapis.com/mcp`. Auth header: `X-Goog-Api-Key`. Available tools verified via `tools/list`: `create_project`, `generate_screen_from_text`, `get_screen`, `list_projects`, `list_screens`, `edit_screens`, `generate_variants`, design system tools. `build_site` and `get_screen_code` are **not** on the official endpoint.
 
-### Adding a new agent
+### Adding a new blueprint agent
 
 1. Create `framework/agents/myagent.agent.ts` implementing the `AgentConfig` interface from `framework/orchestrator/agent-runner.ts`
 2. Add the agent to the `PIPELINE` array in `framework/orchestrator/orchestrator.ts`
 3. Add any new blueprint fields to `framework/schemas/blueprint.types.ts` first, then update `framework/schemas/blueprint.schema.ts`
+
+### Adding a new Stitch review agent
+
+1. Create `framework/agents/stitch-mycheck.agent.ts` exporting a function `(html, page, blueprint) → HtmlReviewResult`
+2. Import and call it in `framework/core/stitch-generator.ts` after `reviewA11y`, merge its patches and findings
 
 ### Output directories (all gitignored)
 
 | Path | Contents |
 |---|---|
 | `output/blueprint/` | `website-blueprint.v1.json` — validated spec |
-| `output/generated-site/` | Next.js 14 App Router source |
-| `output/static-site/` | Pure HTML/CSS/JS, deploy this folder |
-| `output/reports/` | `accessibility-report.html`, `seo-report.html`, `final-report.html` |
+| `output/generated-site/` | Next.js 14 App Router source (template) |
+| `output/static-site/` | Pure HTML/CSS/JS — deploy this (template) |
+| `output/stitch-site/` | Pure HTML/CSS/JS — deploy this (Stitch) |
+| `output/reports/` | Audit reports + `stitch-review-report.html` |
 
 ### OpenAI integration
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Turn a plain Markdown file into a production-ready static website — in minutes.**
 
-[![Version](https://img.shields.io/badge/version-2.0.0-brightgreen.svg)](package.json)
+[![Version](https://img.shields.io/badge/version-2.1.0-brightgreen.svg)](package.json)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D18-green.svg)](package.json)
 [![Next.js](https://img.shields.io/badge/Next.js-14-black.svg)](https://nextjs.org)
@@ -13,7 +13,7 @@
 
 Stitchfy is an open-source, AI-assisted code generation framework that takes a single Markdown file describing a business and produces a fully structured, accessible, SEO-optimized static website — deployable to any static host with no server required.
 
-You describe the business in plain language. Stitchfy runs a pipeline of specialized agents that each handle a distinct concern (intake, UX strategy, SEO, accessibility, frontend assembly), then generates a complete Next.js site and exports it as static HTML/CSS/JS.
+You describe the business in plain language. Stitchfy runs a pipeline of specialized agents that each handle a distinct concern (intake, UX strategy, SEO, accessibility, frontend assembly), then generates a complete static site and exports it as HTML/CSS/JS.
 
 **Who it's built for:** Developers and agencies building websites for small and mid-sized local businesses — beauty salons, nail studios, massage spas, medical clinics, dental offices, restaurants, and similar service providers.
 
@@ -30,7 +30,7 @@ Stitchfy encodes that professional knowledge into a pipeline. Each agent applies
 - The Accessibility Agent enforces WCAG 2.1 AA requirements — skip links, landmarks, keyboard navigation, color contrast, ARIA
 - The Frontend Agent assembles everything into a validated blueprint that drives real code generation
 
-The output is a complete Next.js static site with 12 pre-built components and an HTML audit report — all from one Markdown file.
+The output is a complete static site with pre-built components and an HTML audit report — all from one Markdown file.
 
 ---
 
@@ -46,19 +46,26 @@ npm install
 cp examples/beauty-salon.md input/project.md
 # (edit input/project.md with the real business details)
 
-# 3. Generate blueprint + website
+# 3. Generate the blueprint
 npm run stitchfy
+
+# 4a. Generate website — template-based (no API key required)
 npm run build:site
 
-# 4. Audit accessibility and SEO
+# 4b. Generate website — AI-designed via Google Stitch (requires STITCH_API_KEY)
+npm run build:site:stitch
+
+# 5. Audit accessibility and SEO
 npm run audit
 ```
 
-Open `output/static-site/index.html` in any browser. Deploy the `output/static-site/` folder to S3, Netlify, Vercel, or any static host.
+Open `output/static-site/index.html` (template) or `output/stitch-site/index.html` (Stitch) in any browser.
 
 ---
 
 ## How It Works
+
+### Stage 1 — Blueprint pipeline (shared by both generators)
 
 ```
 input/project.md
@@ -96,22 +103,50 @@ input/project.md
          │
          ▼
 output/blueprint/website-blueprint.v1.json   ← Validated, machine-readable spec
-         │
-         ▼ (npm run build:site)
-┌─────────────────────┐
-│  Site Generator     │  Reads blueprint → writes a complete Next.js app
-└────────┬────────────┘  with real brand data embedded in every component
-         │
-         ▼
-output/generated-site/    ← Next.js 14 App Router project (generated)
-output/static-site/       ← Pure HTML/CSS/JS export (deployable)
-         │
-         ▼ (npm run audit)
-output/reports/
-  ├── accessibility-report.html
-  ├── seo-report.html
-  └── final-report.html
 ```
+
+### Stage 2 — Code generation (choose one)
+
+```
+output/blueprint/website-blueprint.v1.json
+         │
+         ├─── npm run build:site ──────────────────────────────────────────────┐
+         │    Template-based generator                                         │
+         │    Reads blueprint → writes Next.js app → next build → static export│
+         │                                                                     ▼
+         │                                                      output/static-site/
+         │
+         └─── npm run build:site:stitch ──────────────────────────────────────┐
+              Google Stitch MCP generator                                      │
+              Creates Stitch project → generates one AI screen per page        │
+              → fetches HTML → post-processes → SEO Agent review               │
+              → A11y Agent review → auto-patches → writes HTML                 │
+                                                                               ▼
+                                                              output/stitch-site/
+                                                    output/reports/stitch-review-report.html
+
+         └─── npm run audit ──────────────────────────────────────────────────┐
+              Runs on output/static-site/ or output/stitch-site/              │
+                                                                               ▼
+                                              output/reports/accessibility-report.html
+                                              output/reports/seo-report.html
+                                              output/reports/final-report.html
+```
+
+---
+
+## Commands
+
+| Command | Description |
+|---|---|
+| `npm run stitchfy` | Run the full agent pipeline on `input/project.md` |
+| `npm run stitchfy -- --input path/to/file.md` | Run pipeline on a specific input file |
+| `npm run validate` | Validate the input file and the last generated blueprint |
+| `npm run build:site` | Generate Next.js app and export to `output/static-site/` |
+| `npm run build:site -- --blueprint path/to/blueprint.json` | Build from a specific blueprint file |
+| `npm run build:site:stitch` | Generate AI-designed site via Google Stitch MCP |
+| `npm run audit` | Run 14-point HTML accessibility + SEO audit; write HTML reports |
+| `npm run typecheck` | TypeScript type-check the framework without emitting |
 
 ---
 
@@ -181,20 +216,6 @@ See the `examples/` directory for complete working inputs: `beauty-salon.md`, `m
 
 ---
 
-## Commands
-
-| Command | Description |
-|---|---|
-| `npm run stitchfy` | Run the full agent pipeline on `input/project.md` |
-| `npm run stitchfy -- --input path/to/file.md` | Run pipeline on a specific input file |
-| `npm run validate` | Validate the input file and the last generated blueprint |
-| `npm run build:site` | Generate the Next.js app and export to `output/static-site/` |
-| `npm run build:site -- --blueprint path/to/blueprint.json` | Build from a specific blueprint file |
-| `npm run audit` | Run 14-point HTML accessibility + SEO audit; write HTML reports |
-| `npm run typecheck` | TypeScript type-check the framework without emitting |
-
----
-
 ## Generated Output
 
 ### Blueprint
@@ -212,75 +233,120 @@ See the `examples/` directory for complete working inputs: `beauty-salon.md`, `m
 | `frontend` | Component map, routes, asset plan, unsupported features list |
 | `qa` | Lighthouse targets, known limitations, expected report list |
 
-### Pages
+### Template site (`output/static-site/`)
 
-The standard page set for a local business site:
+Generated by `npm run build:site`. A Next.js 14 App Router project built from 12 pre-built accessible React components in `site-template/components/`. Pure HTML/CSS/JS export — no Node.js runtime required.
 
-| Route | Page | Key Sections |
+### Stitch site (`output/stitch-site/`)
+
+Generated by `npm run build:site:stitch`. Each page is AI-designed by Google Stitch using Gemini, then post-processed and reviewed by the framework's SEO and Accessibility agents before being written to disk.
+
+### Reports (`output/reports/`)
+
+| Report | Generator | Contents |
 |---|---|---|
-| `/` | Home | Hero, Services preview, Testimonials, Gallery preview, Booking CTA, Hours |
-| `/services` | Services | ServicesGrid, FAQ, Booking CTA |
-| `/gallery` | Gallery | Filterable GallerySection by service category |
-| `/about` | About Us | Hero, Services, Testimonials, CTA, Contact |
-| `/contact` | Contact | ContactSection, Hours, FAQ |
-| `/book` | Book Online | Booking CTA with external link (Vagaro, phone, or email) |
-
-### Components
-
-12 pre-built accessible React components in `site-template/components/`:
-
-| Component | Description |
-|---|---|
-| `AccessibilitySkipLink` | Visually hidden skip-to-main link; revealed on keyboard focus |
-| `Header` | Sticky header with navigation, phone link, and booking CTA button |
-| `Footer` | 3-column footer: brand + contact, navigation, hours; social icons |
-| `SocialIcons` | Inline SVG icons for Instagram, Facebook, Twitter/X, TikTok, YouTube, Pinterest, Yelp, LinkedIn |
-| `Hero` | Full-width hero with brand gradient or solid background, headline, CTA buttons |
-| `ServicesGrid` | Responsive 3-column service card grid |
-| `HoursBlock` | Operating hours rendered as an accessible `<dl>` list |
-| `ContactSection` | Phone, email, address with `tel:` and `mailto:` links |
-| `CTASection` | Accent-background call-to-action with headline and button |
-| `FAQSection` | Expandable FAQ accordion with ARIA |
-| `GallerySection` | Photo grid with optional category filter buttons and `aria-pressed` state |
-| `TestimonialsSection` | Testimonial card grid with author attribution |
-| `BookingCTA` | Standalone booking section; supports external link, phone, or email |
-
-### Reports
-
-Three self-contained HTML reports in `output/reports/`:
-
-- **`accessibility-report.html`** — WCAG 2.1 AA compliance checklist (30 checks), per-page HTML analysis (14 regex-based checks per route), pass/warn/fail badges
-- **`seo-report.html`** — Per-page meta title + description table, structured data recommendations, Open Graph tag audit
-- **`final-report.html`** — Pipeline summary, route table, unsupported features, recommended next steps
-
-> All reports include the disclaimer: *"Stitchfy completed an automated and structured accessibility-oriented review against the framework checklist. This does not constitute legal certification. Lighthouse scores were not generated in this run."*
+| `accessibility-report.html` | `npm run audit` | WCAG 2.1 AA checklist, per-page HTML analysis |
+| `seo-report.html` | `npm run audit` | Per-page meta, structured data, Open Graph audit |
+| `final-report.html` | `npm run audit` | Pipeline summary, route table, next steps |
+| `stitch-review-report.html` | `npm run build:site:stitch` | Per-page: auto-patches applied, manual findings |
 
 ---
 
-## Deployment
+## Google Stitch Integration
 
-The `output/static-site/` folder is pure static HTML/CSS/JS with no Node.js runtime required. Deploy it anywhere:
+Stitchfy integrates with [Google Stitch](https://stitch.google.com) as an alternative code generator. Stitch uses Gemini to transform text prompts into production HTML/CSS. Stitchfy drives Stitch via its official MCP server, using the blueprint as the structured brief for each page.
+
+### Setup
 
 ```bash
-# AWS S3 + CloudFront
-aws s3 sync output/static-site/ s3://your-bucket --delete
+# Add to your .env file
+STITCH_API_KEY=your-key-here
 
-# Netlify
-netlify deploy --prod --dir output/static-site
-
-# Vercel
-vercel --prebuilt output/static-site
-
-# GitHub Pages — copy contents into your gh-pages branch
+# Optional: choose the generation model (default: GEMINI_3_1_PRO)
+STITCH_MODEL=GEMINI_3_FLASH   # faster; GEMINI_3_1_PRO for higher quality
 ```
 
-Or simply open `output/static-site/index.html` directly in a browser for local preview.
+### Stitch pipeline flow
+
+```
+blueprint.json
+    ↓
+Create Stitch project
+    ↓
+For each page:
+  generate_screen_from_text   ← Gemini generates the visual design
+    ↓
+  get_screen                  ← fetch HTML via downloadUrl
+    ↓
+  post-processor              ← inject SEO meta, skip link, lang, JSON-LD
+    ↓
+  stitch-seo.agent            ← fix JSON-LD @type/url/hours, flag dead links
+    ↓
+  stitch-a11y.agent           ← fix data-alt→alt, nav aria-label, icon aria-hidden
+    ↓
+  stitch-patcher              ← apply all attribute-level patches
+    ↓
+  write HTML                  → output/stitch-site/{route}/index.html
+    ↓
+stitch-review-reporter        → output/reports/stitch-review-report.html
+```
+
+### What the review agents do
+
+After Stitch generates HTML, two agents run on each page before it is written to disk:
+
+**SEO Agent (`stitch-seo.agent.ts`)**
+- Patches: rewrites JSON-LD with correct `@type` (e.g. `BeautySalon`), absolute URL, and Schema.org-compliant opening hours (24hr format, individual days)
+- Flags: missing `og:image`, relative canonical URL, meta description that contains internal blueprint text, title exceeding 60 chars, dead links to routes not in the blueprint
+
+**Accessibility Agent (`stitch-a11y.agent.ts`)**
+- Patches: converts `data-alt` → `alt` on all `<img>` elements, adds `aria-label` to unlabelled `<nav>`, adds `aria-label="Open menu"` to the icon-only mobile menu button, replaces `focus:outline-none` with a visible focus ring, adds `role="img"` and `aria-label` to star rating groups, adds `aria-hidden="true"` to decorative material icons
+- Flags: footer links without a `<nav>` landmark, any remaining images without alt text, multiple `focus:outline-none` occurrences
+
+All patches are **attribute-level only** — no structural changes, no content edits. The review report shows exactly what was patched automatically and what requires human review before deploying.
+
+### Template vs. Stitch — choosing a generator
+
+| | Template (`build:site`) | Stitch (`build:site:stitch`) |
+|---|---|---|
+| API key required | No | Yes (STITCH_API_KEY) |
+| Visual quality | Consistent, predictable | Higher — AI-generated layouts |
+| Control | Full | Partial — Stitch decides visual detail |
+| Speed | Fast (no network calls) | Slower (~30–90s per page) |
+| Offline use | Yes | No |
+| Deterministic output | Yes | No — reruns differ |
+| Post-generation review | Via `npm run audit` | Built-in (agents run automatically) |
+
+---
+
+## OpenAI Integration
+
+All five blueprint agents are structured to support an OpenAI API call but run **fully deterministically** in the default mode — no API key required. The integration point is marked in each agent file:
+
+```typescript
+// OPENAI INTEGRATION POINT:
+//   const response = await openai.chat.completions.create({
+//     model: process.env.OPENAI_MODEL ?? "gpt-4o",
+//     messages: [
+//       { role: "system", content: readPrompt("ux.prompt.md") },
+//       { role: "user", content: JSON.stringify(businessData) },
+//     ],
+//     response_format: { type: "json_object" },
+//   });
+```
+
+To enable AI generation:
+1. Add `OPENAI_API_KEY=sk-...` to a `.env` file in the project root
+2. Replace the deterministic logic in each agent with the commented API call
+3. Parse the `response.choices[0].message.content` into the expected typed output
+
+The framework's Zod schema validates the agent output regardless of whether it comes from AI or local logic — so the pipeline stays safe either way.
 
 ---
 
 ## Industry Support
 
-The UX and SEO agents apply industry-specific defaults for color palette, typography, page strategy, JSON-LD schema type, and gallery content. Supported verticals:
+The UX and SEO agents apply industry-specific defaults for color palette, typography, page strategy, JSON-LD schema type, and gallery content. The Stitch SEO agent uses the same mapping to set the correct `@type` in the generated JSON-LD.
 
 | Industry keyword | Schema.org type | Palette style | Gallery seeds |
 |---|---|---|---|
@@ -308,32 +374,9 @@ Brand colors from `input/project.md` are wired into CSS custom properties applie
 
 The hero background is derived from `ux.heroStyle` — a structured field the UX Agent generates from the palette — so the hero always uses the actual brand gradient rather than defaulting to white.
 
-Gallery images use [picsum.photos](https://picsum.photos) with deterministic seeds for realistic layout previews. Replace the URLs in `site.config.ts` with real photos before going live.
+In the Stitch generator, these same values are embedded directly into each page's generation prompt so Stitch stays constrained to the blueprint's brand.
 
----
-
-## OpenAI Integration
-
-All five agents are structured to support an OpenAI API call but run **fully deterministically** in the default mode — no API key required. The integration point is marked in each agent file:
-
-```typescript
-// OPENAI INTEGRATION POINT:
-//   const response = await openai.chat.completions.create({
-//     model: process.env.OPENAI_MODEL ?? "gpt-4o",
-//     messages: [
-//       { role: "system", content: readPrompt("ux.prompt.md") },
-//       { role: "user", content: JSON.stringify(businessData) },
-//     ],
-//     response_format: { type: "json_object" },
-//   });
-```
-
-To enable AI generation:
-1. Add `OPENAI_API_KEY=sk-...` to a `.env` file in the project root
-2. Replace the deterministic logic in each agent with the commented API call
-3. Parse the `response.choices[0].message.content` into the expected typed output
-
-The framework's Zod schema validates the agent output regardless of whether it comes from AI or local logic — so the pipeline stays safe either way.
+Gallery images use [picsum.photos](https://picsum.photos) in the template generator. The Stitch generator uses Gemini-generated images via Google's CDN. Replace the URLs before going live.
 
 ---
 
@@ -352,6 +395,25 @@ Booking links point to third-party platforms the business already uses (Vagaro, 
 
 ---
 
+## Deployment
+
+Both `output/static-site/` and `output/stitch-site/` are pure static HTML/CSS/JS with no Node.js runtime required. Deploy either folder anywhere:
+
+```bash
+# AWS S3 + CloudFront
+aws s3 sync output/stitch-site/ s3://your-bucket --delete
+
+# Netlify
+netlify deploy --prod --dir output/stitch-site
+
+# Vercel
+vercel --prebuilt output/stitch-site
+
+# GitHub Pages — copy contents into your gh-pages branch
+```
+
+---
+
 ## Repository Structure
 
 ```
@@ -366,18 +428,27 @@ stitchfy/
 │
 ├── framework/
 │   ├── orchestrator/
-│   │   ├── orchestrator.ts       ← Pipeline driver (9 steps)
-│   │   ├── agent-runner.ts       ← Runs each agent, handles errors
+│   │   ├── orchestrator.ts       ← Blueprint pipeline driver (9 steps)
+│   │   ├── agent-runner.ts       ← Runs each blueprint agent, handles errors
 │   │   └── workflow-state.ts     ← Shared state passed between agents
 │   ├── agents/
-│   │   ├── intake.agent.ts       ← Stage 1: business data extraction
-│   │   ├── ux.agent.ts           ← Stage 2: UX strategy + hero spec
-│   │   ├── seo.agent.ts          ← Stage 3: meta tags + structured data
-│   │   ├── accessibility.agent.ts← Stage 4: WCAG 2.1 AA checklist
-│   │   └── frontend.agent.ts     ← Stage 5: component map + routes
+│   │   ├── intake.agent.ts       ← Blueprint stage 1: business data extraction
+│   │   ├── ux.agent.ts           ← Blueprint stage 2: UX strategy + hero spec
+│   │   ├── seo.agent.ts          ← Blueprint stage 3: meta tags + structured data
+│   │   ├── accessibility.agent.ts← Blueprint stage 4: WCAG 2.1 AA checklist
+│   │   ├── frontend.agent.ts     ← Blueprint stage 5: component map + routes
+│   │   ├── stitch-seo.agent.ts   ← Stitch review: SEO audit + JSON-LD patch
+│   │   ├── stitch-a11y.agent.ts  ← Stitch review: A11y audit + attribute patches
+│   │   └── stitch-html-review.types.ts ← Shared types for review agents
 │   ├── core/
-│   │   ├── site-generator.ts     ← Blueprint → Next.js source code
-│   │   ├── report-generator.ts   ← Static HTML audit reports
+│   │   ├── site-generator.ts     ← Blueprint → Next.js source code (template)
+│   │   ├── stitch-client.ts      ← Google Stitch MCP JSON-RPC 2.0 client
+│   │   ├── stitch-generator.ts   ← Stitch pipeline orchestrator
+│   │   ├── stitch-prompt-builder.ts ← Blueprint → per-page Stitch prompt
+│   │   ├── stitch-post-processor.ts ← Injects SEO meta + base a11y into Stitch HTML
+│   │   ├── stitch-patcher.ts     ← Applies agent patches to HTML string
+│   │   ├── stitch-review-reporter.ts ← Generates stitch-review-report.html
+│   │   ├── report-generator.ts   ← Static HTML audit reports (template generator)
 │   │   ├── markdown-parser.ts    ← Parses input/project.md
 │   │   └── blueprint-writer.ts   ← Writes output/blueprint/*.json
 │   ├── schemas/
@@ -396,17 +467,25 @@ stitchfy/
 │
 ├── scripts/
 │   ├── run-stitchfy.ts           ← Entry point: npm run stitchfy
-│   ├── build-site.ts             ← Entry point: npm run build:site
+│   ├── build-site.ts             ← Entry point: npm run build:site (template)
+│   ├── build-site-stitch.ts      ← Entry point: npm run build:site:stitch
 │   ├── audit-site.ts             ← Entry point: npm run audit
 │   └── validate.ts               ← Entry point: npm run validate
 │
 ├── output/                       ← All generated artifacts (gitignored)
 │   ├── blueprint/
-│   ├── generated-site/
-│   ├── static-site/
+│   ├── generated-site/           ← Next.js source (template generator)
+│   ├── static-site/              ← Deployable HTML (template generator)
+│   ├── stitch-site/              ← Deployable HTML (Stitch generator)
 │   └── reports/
+│       ├── accessibility-report.html
+│       ├── seo-report.html
+│       ├── final-report.html
+│       └── stitch-review-report.html
 │
-├── assets/                       ← Project images and diagrams
+├── examples/
+├── assets/
+├── .env.example                  ← OPENAI_API_KEY + STITCH_API_KEY placeholders
 ├── LICENSE
 ├── NOTICE
 └── package.json
@@ -418,10 +497,11 @@ stitchfy/
 
 1. Fork the repository
 2. Create a feature branch: `git checkout -b feature/my-feature`
-3. Agents live in `framework/agents/` — one file per stage, following the `AgentConfig` interface in `framework/orchestrator/agent-runner.ts`
-4. Add or update the Zod schema in `framework/schemas/blueprint.schema.ts` for any new blueprint fields
-5. Keep TypeScript types in `framework/schemas/blueprint.types.ts` in sync with the Zod schema
-6. Run `npm run typecheck` before submitting a pull request
+3. Blueprint agents live in `framework/agents/` — one file per stage, following the `AgentConfig` interface in `framework/orchestrator/agent-runner.ts`
+4. Stitch review agents live in `framework/agents/stitch-*.agent.ts` — implement `reviewSEO` / `reviewA11y` returning `HtmlReviewResult` from `stitch-html-review.types.ts`
+5. Add or update the Zod schema in `framework/schemas/blueprint.schema.ts` for any new blueprint fields
+6. Keep TypeScript types in `framework/schemas/blueprint.types.ts` in sync with the Zod schema
+7. Run `npm run typecheck` before submitting a pull request
 
 When adding a new component to `site-template/components/`, the site generator picks it up automatically — no additional copy step needed.
 
@@ -435,4 +515,4 @@ Copyright 2024–2025 Devify LLC
 
 ---
 
-*Stitchfy v2.0.0 — Built by [Devify LLC](https://github.com/devifyllc)*
+*Stitchfy v2.1.0 — Built by [Devify LLC](https://github.com/devifyllc)*

--- a/framework/agents/stitch-a11y.agent.ts
+++ b/framework/agents/stitch-a11y.agent.ts
@@ -1,0 +1,197 @@
+/**
+ * stitch-a11y.agent — Reviews Stitch-generated HTML for accessibility issues.
+ *
+ * Runs after postProcessPage (skip link, lang, id="main-content" already done).
+ * Catches patterns Stitch consistently introduces:
+ *   - <img data-alt="..."> instead of alt="..." (Stitch stores alt in a custom attr)
+ *   - <nav> without aria-label (multiple nav landmarks need distinguishing labels)
+ *   - Mobile menu <button> with icon-only content and no aria-label
+ *   - focus:outline-none on interactive elements (WCAG 2.4.7 violation)
+ *   - Star rating icon groups without role/aria-label
+ *   - Decorative material icons that are read aloud by screen readers
+ *
+ * Returns patches (attribute-level only, safe to auto-apply) and findings
+ * that require human judgment before deploying.
+ */
+
+import type { PageDefinition, WebsiteBlueprint } from "../schemas/blueprint.types.js";
+import type { HtmlPatch, HtmlReviewResult, ReviewFinding } from "./stitch-html-review.types.js";
+
+// Material icon names that are decorative when adjacent to visible text.
+// These will receive aria-hidden="true" automatically.
+const DECORATIVE_ICONS = new Set([
+  "location_on", "schedule", "arrow_forward", "arrow_back",
+  "arrow_right_alt", "chevron_right", "chevron_left",
+  "phone", "email", "place", "map", "directions",
+  "open_in_new", "check", "check_circle", "info",
+  "menu", // icon-only button is handled separately with aria-label
+]);
+
+export function reviewA11y(
+  html: string,
+  _page: PageDefinition,
+  _blueprint: WebsiteBlueprint
+): HtmlReviewResult {
+  const patches: HtmlPatch[] = [];
+  const findings: ReviewFinding[] = [];
+
+  // ── 1. data-alt → alt on <img> elements ─────────────────────────────────────
+  // Stitch stores alt descriptions in data-alt, not the standard alt attribute.
+  // Screen readers ignore data-alt entirely and read the full src URL instead.
+  if (/(<img\b[^>]*?)\bdata-alt=/i.test(html)) {
+    patches.push({
+      description: 'Convert data-alt to alt on all <img> elements (WCAG 1.1.1)',
+      find: /(<img\b[^>]*?)\bdata-alt=/gi,
+      replace: "$1 alt=",
+      replaceAll: true,
+    });
+  }
+
+  // ── 2. <nav> missing aria-label ─────────────────────────────────────────────
+  // When a page has more than one nav landmark, each must be distinguishable.
+  if (/<nav\b(?![^>]*aria-label)[^>]*>/i.test(html)) {
+    patches.push({
+      description: 'Add aria-label="Main navigation" to unlabelled <nav> (WCAG 1.3.6)',
+      find: /<nav\b(?![^>]*aria-label)([^>]*)>/i,
+      replace: '<nav aria-label="Main navigation"$1>',
+    });
+  }
+
+  // ── 3. Mobile menu button: icon-only, no aria-label ─────────────────────────
+  // Pattern: <button ...>  <span class="material-symbols-outlined">menu</span> </button>
+  // The button has no accessible name — screen readers announce "button" only.
+  if (/(<button[^>]*md:hidden[^>]*focus:outline-none[^>]*>)/i.test(html)) {
+    patches.push({
+      description:
+        'Add aria-label to mobile menu button and fix focus outline removal (WCAG 4.1.2, 2.4.7)',
+      find: /(<button)([^>]*\bmd:hidden\b[^>]*)\bfocus:outline-none\b([^>]*>)/gi,
+      replace: '$1 aria-label="Open menu"$2 focus:ring-2 focus:ring-primary focus:ring-offset-2$3',
+      replaceAll: true,
+    });
+  } else if (/(<button[^>]*md:hidden[^>]*>)/i.test(html)) {
+    // Same button without the focus class pattern
+    patches.push({
+      description: 'Add aria-label to mobile menu button (WCAG 4.1.2)',
+      find: /(<button)([^>]*\bmd:hidden\b[^>]*>)/gi,
+      replace: '$1 aria-label="Open menu"$2',
+      replaceAll: true,
+    });
+  }
+
+  // ── 4. Star rating groups: not announced as a rating ────────────────────────
+  // Stitch renders 5 <span>star</span> icons. Screen readers say "star star star…"
+  // Fix: wrap the group with role="img" aria-label="5 out of 5 stars"
+  const starGroupPattern = /<div([^>]*)>\s*(?:<span[^>]*>star<\/span>\s*){3,}/i;
+  if (starGroupPattern.test(html)) {
+    patches.push({
+      description: 'Add role="img" aria-label to star rating groups (WCAG 1.1.1)',
+      find: /(<div)([^>]*\bflex\b[^>]*\btext-primary\b[^>]*mb-sm[^>]*>)(\s*<span[^>]*material-symbols)/gi,
+      replace: '$1 role="img" aria-label="5 out of 5 stars"$2$3',
+      replaceAll: true,
+    });
+  }
+
+  // ── 5. Decorative material icons: not aria-hidden ───────────────────────────
+  // Icons like location_on, schedule, arrow_forward appear next to visible text.
+  // Without aria-hidden, screen readers announce them mid-sentence.
+  for (const iconName of DECORATIVE_ICONS) {
+    // Match the icon span without an existing aria-hidden attribute
+    const find = new RegExp(
+      `(<span\\b(?![^>]*aria-hidden)[^>]*\\bmaterial-symbols-outlined\\b[^>]*>)(${iconName})(<\\/span>)`,
+      "gi"
+    );
+    if (find.test(html)) {
+      patches.push({
+        description: `Add aria-hidden="true" to decorative icon "${iconName}" (WCAG 1.1.1)`,
+        find: new RegExp(
+          `(<span\\b(?![^>]*aria-hidden)[^>]*\\bmaterial-symbols-outlined\\b[^>]*>)(${iconName})(<\\/span>)`,
+          "gi"
+        ),
+        replace: '$1$2$3'.replace(
+          '$1',
+          `<span aria-hidden="true" `
+        ).replace(
+          /^<span aria-hidden="true" /,
+          // Rebuild properly — replace opening tag inline
+          ''
+        ),
+      });
+    }
+  }
+
+  // Simpler, more reliable approach for decorative icons — direct string patches
+  patches.push(...buildDecorativeIconPatches(html));
+
+  // ── 6. Footer links without <nav> wrapper ───────────────────────────────────
+  if (/<footer[^>]*>[\s\S]*?<a\b/i.test(html) && !/<footer[^>]*>[\s\S]*?<nav\b/i.test(html)) {
+    findings.push({
+      severity: "info",
+      category: "accessibility",
+      rule: "WCAG 1.3.1: footer navigation landmark",
+      description: "Footer contains links but no <nav> landmark. Keyboard and AT users cannot jump to footer nav.",
+      recommendation:
+        'Wrap footer links in <nav aria-label="Footer navigation">. This is a structural change — not auto-patched.',
+    });
+  }
+
+  // ── 7. focus:outline-none on non-button elements ────────────────────────────
+  const outlineNoneCount = (html.match(/\bfocus:outline-none\b/g) ?? []).length;
+  // We already patch the button above; flag any remaining occurrences
+  if (outlineNoneCount > 1) {
+    findings.push({
+      severity: "warning",
+      category: "accessibility",
+      rule: "WCAG 2.4.7: focus visible",
+      description: `Found ${outlineNoneCount} uses of focus:outline-none. One (the menu button) is auto-patched. Others may suppress focus indicators.`,
+      recommendation:
+        "Search for focus:outline-none in the page and replace with focus:ring-* utilities.",
+    });
+  }
+
+  // ── 8. <img> with src but no alt (after the data-alt patch) ─────────────────
+  // This catches any images Stitch added without any alt attribute at all.
+  const imgNoAlt = /<img\b(?![^>]*\balt=)[^>]*>/gi;
+  const orphanImgs = html.match(imgNoAlt) ?? [];
+  if (orphanImgs.length > 0) {
+    // Only flag images that still have no alt after the data-alt patch is applied
+    const withoutDataAlt = orphanImgs.filter((t) => !t.includes("data-alt="));
+    if (withoutDataAlt.length > 0) {
+      findings.push({
+        severity: "error",
+        category: "accessibility",
+        rule: "WCAG 1.1.1: non-text content",
+        description: `${withoutDataAlt.length} <img> element(s) have no alt attribute and no data-alt fallback.`,
+        recommendation:
+          "Add alt text to content images or alt=\"\" to purely decorative ones.",
+      });
+    }
+  }
+
+  return { patches, findings };
+}
+
+// ─── Decorative icon patches ──────────────────────────────────────────────────
+// More reliable than a generic regex loop: build concrete patches per icon.
+
+function buildDecorativeIconPatches(html: string): HtmlPatch[] {
+  const result: HtmlPatch[] = [];
+  for (const iconName of DECORATIVE_ICONS) {
+    // Match any <span ... material-symbols-outlined ...>ICON</span> without aria-hidden
+    const testRe = new RegExp(
+      `<span(?![^>]*aria-hidden)[^>]*material-symbols-outlined[^>]*>${iconName}</span>`,
+      "i"
+    );
+    if (!testRe.test(html)) continue;
+
+    result.push({
+      description: `aria-hidden decorative icon "${iconName}"`,
+      find: new RegExp(
+        `(<span)((?![^>]*aria-hidden)[^>]*\\bmaterial-symbols-outlined\\b[^>]*>)(${iconName}</span>)`,
+        "gi"
+      ),
+      replace: '$1 aria-hidden="true"$2$3',
+      replaceAll: true,
+    });
+  }
+  return result;
+}

--- a/framework/agents/stitch-html-review.types.ts
+++ b/framework/agents/stitch-html-review.types.ts
@@ -1,0 +1,55 @@
+/**
+ * Shared types for the Stitch HTML review agents.
+ *
+ * These agents run AFTER Google Stitch generates the HTML and AFTER the
+ * post-processor injects SEO/a11y attributes. Their job is to catch what
+ * Stitch introduced that neither tool covers, then either auto-patch it
+ * (attribute-level only) or flag it for manual review before deploying.
+ */
+
+// ─── Patch ────────────────────────────────────────────────────────────────────
+
+/**
+ * A single string find-and-replace operation on the HTML.
+ * The patcher applies patches sequentially and records which ones matched.
+ *
+ * Patches MUST be attribute-level only — no structural changes, no content
+ * edits, no element moves. The boundary: if removing the patch leaves the
+ * visual layout unchanged, it's safe.
+ */
+export interface HtmlPatch {
+  description: string;
+  find: string | RegExp;
+  replace: string;
+  replaceAll?: boolean;
+}
+
+// ─── Finding ──────────────────────────────────────────────────────────────────
+
+export type FindingSeverity = "error" | "warning" | "info";
+export type FindingCategory = "seo" | "accessibility";
+
+export interface ReviewFinding {
+  severity: FindingSeverity;
+  category: FindingCategory;
+  rule: string;
+  description: string;
+  recommendation: string;
+}
+
+// ─── Agent result ─────────────────────────────────────────────────────────────
+
+export interface HtmlReviewResult {
+  patches: HtmlPatch[];
+  findings: ReviewFinding[];
+}
+
+// ─── Per-page summary (used by reporter) ─────────────────────────────────────
+
+export interface PageReviewSummary {
+  pageId: string;
+  route: string;
+  patchesApplied: string[];
+  patchesSkipped: string[];
+  findings: ReviewFinding[];
+}

--- a/framework/agents/stitch-seo.agent.ts
+++ b/framework/agents/stitch-seo.agent.ts
@@ -1,0 +1,226 @@
+/**
+ * stitch-seo.agent — Reviews Stitch-generated HTML for SEO issues.
+ *
+ * Runs after postProcessPage (so our meta tags are already injected).
+ * Catches what Stitch introduces that our post-processor doesn't cover:
+ *   - JSON-LD @type, url field, and opening hours format
+ *   - Links to routes that don't exist in the blueprint (Stitch invents these)
+ *   - Missing og:image / twitter:image
+ *   - Meta description that is still the blueprint's internal purpose text
+ *   - Title length
+ *
+ * Returns patches (safe to auto-apply) and findings (require human action).
+ */
+
+import type { PageDefinition, WebsiteBlueprint } from "../schemas/blueprint.types.js";
+import type { HtmlPatch, HtmlReviewResult, ReviewFinding } from "./stitch-html-review.types.js";
+
+export function reviewSEO(
+  html: string,
+  page: PageDefinition,
+  blueprint: WebsiteBlueprint
+): HtmlReviewResult {
+  const patches: HtmlPatch[] = [];
+  const findings: ReviewFinding[] = [];
+
+  // ── 1. JSON-LD: rewrite with correct @type, url, and hours ──────────────────
+  if (html.includes('"@context": "https://schema.org"') && page.id === "home") {
+    const correctJsonLd = buildCorrectJsonLd(blueprint);
+    patches.push({
+      description: `JSON-LD: fix @type (${schemaTypeForIndustry(blueprint.business.industry)}), url, and opening hours format`,
+      find: /<script type="application\/ld\+json">[\s\S]*?<\/script>/,
+      replace: `<script type="application/ld+json">\n${JSON.stringify(correctJsonLd, null, 2)}\n</script>`,
+    });
+  }
+
+  // ── 2. Dead links: routes Stitch invented that don't exist in the blueprint ──
+  const validRoutes = new Set(blueprint.pages.map((p) => p.path));
+  // Common pages Stitch adds on its own
+  const stitch_invented = ["/privacy", "/terms", "/accessibility", "/sitemap", "/blog", "/faq"];
+  const deadLinks = stitch_invented.filter((r) => !validRoutes.has(r) && html.includes(`href="${r}"`));
+
+  if (deadLinks.length > 0) {
+    findings.push({
+      severity: "warning",
+      category: "seo",
+      rule: "SEO: dead internal links",
+      description: `Found ${deadLinks.length} link(s) to routes not in the blueprint: ${deadLinks.join(", ")}`,
+      recommendation:
+        "Either add these pages to the blueprint and re-run the pipeline, or remove the links before deploying.",
+    });
+  }
+
+  // ── 3. og:image / twitter:image missing ─────────────────────────────────────
+  if (!html.includes('property="og:image"') && !html.includes("property='og:image'")) {
+    findings.push({
+      severity: "error",
+      category: "seo",
+      rule: "SEO: og:image missing",
+      description: "No og:image meta tag found. Social sharing previews will have no image.",
+      recommendation:
+        'Add <meta property="og:image" content="https://yourdomain.com/og-image.jpg"> in the blueprint\'s openGraph config.',
+    });
+  }
+
+  // ── 4. Meta description looks like blueprint purpose text ───────────────────
+  const descMatch = html.match(/<meta[^>]+name=["']description["'][^>]+content=["']([^"']+)["']/i)
+    ?? html.match(/<meta[^>]+content=["']([^"']+)["'][^>]+name=["']description["']/i);
+
+  if (descMatch) {
+    const desc = descMatch[1];
+    const purposePhrases = [
+      "convert visitors",
+      "showcase brand",
+      "drive bookings",
+      "highlight services",
+      "establish credibility",
+    ];
+    const looksLikePurpose = purposePhrases.some((p) =>
+      desc.toLowerCase().includes(p.toLowerCase())
+    );
+    if (looksLikePurpose) {
+      findings.push({
+        severity: "error",
+        category: "seo",
+        rule: "SEO: meta description is internal blueprint text",
+        description: `Meta description appears to be the page's internal purpose field: "${desc.slice(0, 80)}..."`,
+        recommendation:
+          "Replace with a consumer-facing description (50–160 chars) before deploying. Update seo.pageMeta in the blueprint.",
+      });
+    } else if (desc.length < 50) {
+      findings.push({
+        severity: "warning",
+        category: "seo",
+        rule: "SEO: meta description too short",
+        description: `Meta description is ${desc.length} chars (minimum 50 recommended).`,
+        recommendation: "Expand the description in the blueprint's seo.pageMeta for this page.",
+      });
+    } else if (desc.length > 160) {
+      findings.push({
+        severity: "warning",
+        category: "seo",
+        rule: "SEO: meta description too long",
+        description: `Meta description is ${desc.length} chars (maximum 160 before Google truncates).`,
+        recommendation: "Shorten the description in the blueprint's seo.pageMeta for this page.",
+      });
+    }
+  }
+
+  // ── 5. Title length ──────────────────────────────────────────────────────────
+  const titleMatch = html.match(/<title>([^<]+)<\/title>/i);
+  if (titleMatch) {
+    // HTML entities count as their decoded character for display length
+    const title = titleMatch[1].replace(/&amp;/g, "&").replace(/&quot;/g, '"');
+    if (title.length > 60) {
+      findings.push({
+        severity: "warning",
+        category: "seo",
+        rule: "SEO: title too long",
+        description: `Page title is ${title.length} chars. Google truncates at ~60 in SERPs.`,
+        recommendation: "Shorten the title in the blueprint's seo.pageMeta for this page.",
+      });
+    }
+  }
+
+  // ── 6. Canonical / og:url relative ──────────────────────────────────────────
+  if (html.includes('href="/"') && html.includes('rel="canonical"')) {
+    findings.push({
+      severity: "warning",
+      category: "seo",
+      rule: "SEO: canonical URL is relative",
+      description: 'Canonical link is set to "/" (relative). Search engines expect an absolute URL.',
+      recommendation:
+        "Set openGraph.url in the blueprint (e.g. https://glowandgobar.com) before deploying.",
+    });
+  }
+
+  return { patches, findings };
+}
+
+// ─── JSON-LD builder ──────────────────────────────────────────────────────────
+
+function buildCorrectJsonLd(blueprint: WebsiteBlueprint): Record<string, unknown> {
+  const { business, seo } = blueprint;
+  const siteUrl = seo.openGraph["url"] ?? "";
+
+  const ld: Record<string, unknown> = {
+    "@context": "https://schema.org",
+    "@type": schemaTypeForIndustry(business.industry),
+    name: business.name,
+    description: business.description,
+    url: siteUrl || undefined,
+    telephone: business.phone,
+    email: business.email,
+    address: {
+      "@type": "PostalAddress",
+      streetAddress: business.address,
+    },
+  };
+
+  const hours = buildOpeningHoursSpec(business.operatingHours);
+  if (hours.length > 0) ld["openingHoursSpecification"] = hours;
+
+  const socials = Object.values(business.socialLinks).filter(Boolean);
+  if (socials.length > 0) ld["sameAs"] = socials;
+
+  return ld;
+}
+
+function schemaTypeForIndustry(industry: string): string {
+  const s = industry.toLowerCase();
+  if (/beauty|salon|hair|nail|lash|blowout/i.test(s)) return "BeautySalon";
+  if (/wellness|massage|yoga|spa/i.test(s)) return "HealthAndBeautyBusiness";
+  if (/medical|clinic|dental|doctor/i.test(s)) return "MedicalClinic";
+  if (/restaurant|cafe|bistro|dining/i.test(s)) return "Restaurant";
+  return "LocalBusiness";
+}
+
+// ─── Opening hours converter ──────────────────────────────────────────────────
+
+const DAY_EXPANSIONS: Record<string, string[]> = {
+  "Monday–Wednesday": ["Monday", "Tuesday", "Wednesday"],
+  "Monday-Wednesday": ["Monday", "Tuesday", "Wednesday"],
+  "Monday–Thursday": ["Monday", "Tuesday", "Wednesday", "Thursday"],
+  "Monday-Thursday": ["Monday", "Tuesday", "Wednesday", "Thursday"],
+  "Monday–Friday": ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"],
+  "Monday-Friday": ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"],
+  "Thursday–Friday": ["Thursday", "Friday"],
+  "Thursday-Friday": ["Thursday", "Friday"],
+  "Saturday–Sunday": ["Saturday", "Sunday"],
+  "Saturday-Sunday": ["Saturday", "Sunday"],
+  Weekdays: ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"],
+  Weekends: ["Saturday", "Sunday"],
+};
+
+const ALL_DAYS = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"];
+
+function expandDays(key: string): string[] {
+  return DAY_EXPANSIONS[key] ?? (ALL_DAYS.includes(key) ? [key] : [key]);
+}
+
+function to24h(time: string): string {
+  const m = time.trim().match(/^(\d{1,2}):(\d{2})\s*(AM|PM)$/i);
+  if (!m) return time;
+  let h = parseInt(m[1]);
+  const min = m[2];
+  const period = m[3].toUpperCase();
+  if (period === "PM" && h !== 12) h += 12;
+  if (period === "AM" && h === 12) h = 0;
+  return `${String(h).padStart(2, "0")}:${min}`;
+}
+
+function buildOpeningHoursSpec(
+  operatingHours: Record<string, string>
+): Record<string, unknown>[] {
+  const result: Record<string, unknown>[] = [];
+  for (const [dayKey, rangeStr] of Object.entries(operatingHours)) {
+    if (/closed/i.test(rangeStr)) continue;
+    const parts = rangeStr.split(/[–\-]/).map((s) => s.trim());
+    const opens = parts[0] ? to24h(parts[0]) : "";
+    const closes = parts[1] ? to24h(parts[1]) : "";
+    for (const day of expandDays(dayKey)) {
+      result.push({ "@type": "OpeningHoursSpecification", dayOfWeek: day, opens, closes });
+    }
+  }
+  return result;
+}

--- a/framework/core/report-generator.ts
+++ b/framework/core/report-generator.ts
@@ -37,13 +37,16 @@ export interface ReportData {
 
 // ─── Entry points ─────────────────────────────────────────────────────────────
 
-export function generateReports(data: ReportData, outputDir: string): void {
+/**
+ * @param prefix  Optional filename prefix, e.g. "stitch-" → stitch-accessibility-report.html
+ */
+export function generateReports(data: ReportData, outputDir: string, prefix = ""): void {
   const reportsDir = path.join(outputDir, "reports");
   fs.mkdirSync(reportsDir, { recursive: true });
 
-  fs.writeFileSync(path.join(reportsDir, "accessibility-report.html"), generateAccessibilityReport(data));
-  fs.writeFileSync(path.join(reportsDir, "seo-report.html"), generateSEOReport(data));
-  fs.writeFileSync(path.join(reportsDir, "final-report.html"), generateFinalReport(data));
+  fs.writeFileSync(path.join(reportsDir, `${prefix}accessibility-report.html`), generateAccessibilityReport(data));
+  fs.writeFileSync(path.join(reportsDir, `${prefix}seo-report.html`), generateSEOReport(data));
+  fs.writeFileSync(path.join(reportsDir, `${prefix}final-report.html`), generateFinalReport(data));
 }
 
 // ─── Static HTML analysis ──────────────────────────────────────────────────────

--- a/framework/core/stitch-client.ts
+++ b/framework/core/stitch-client.ts
@@ -1,0 +1,271 @@
+/**
+ * stitch-client — Thin JSON-RPC 2.0 client for the Google Stitch MCP server.
+ *
+ * Protocol: HTTP POST to https://stitch.googleapis.com/mcp
+ * Auth:     X-Goog-Api-Key header
+ * Spec:     JSON-RPC 2.0 — method "tools/call", tool name in params.name
+ *
+ * Every tool response wraps its payload in:
+ *   result.content[0].text  (string — may be JSON or raw HTML)
+ *
+ * Available tools (verified via tools/list on the official endpoint):
+ *   create_project, get_project, list_projects, list_screens,
+ *   get_screen, generate_screen_from_text, edit_screens,
+ *   generate_variants, upload_design_md, create_design_system,
+ *   create_design_system_from_design_md, update_design_system,
+ *   list_design_systems, apply_design_system
+ *
+ * NOTE: build_site, get_screen_code are NOT available on the official endpoint —
+ * those exist only in third-party community MCP wrappers.
+ */
+
+const DEFAULT_ENDPOINT = "https://stitch.googleapis.com/mcp";
+
+// ─── Wire types ───────────────────────────────────────────────────────────────
+
+interface RpcRequest {
+  jsonrpc: "2.0";
+  method: "tools/call";
+  params: { name: string; arguments: Record<string, unknown> };
+  id: number;
+}
+
+interface RpcResponse {
+  jsonrpc: "2.0";
+  id: number;
+  result?: { content: Array<{ type: string; text: string }> };
+  error?: { code: number; message: string; data?: unknown };
+}
+
+// ─── Public result types ──────────────────────────────────────────────────────
+
+export type StitchModelId = "GEMINI_3_1_PRO" | "GEMINI_3_FLASH";
+
+export interface StitchPage {
+  route: string;
+  html: string;
+}
+
+// ─── Client ──────────────────────────────────────────────────────────────────
+
+export class StitchClient {
+  private apiKey: string;
+  private endpoint: string;
+  private nextId = 0;
+
+  constructor(apiKey: string, endpoint = DEFAULT_ENDPOINT) {
+    if (!apiKey) throw new Error("StitchClient: apiKey must not be empty");
+    this.apiKey = apiKey;
+    this.endpoint = endpoint;
+  }
+
+  // ── Low-level call ────────────────────────────────────────────────────────
+
+  private async call(toolName: string, args: Record<string, unknown>): Promise<string> {
+    const id = ++this.nextId;
+    const body: RpcRequest = {
+      jsonrpc: "2.0",
+      method: "tools/call",
+      params: { name: toolName, arguments: args },
+      id,
+    };
+
+    let res: Response;
+    try {
+      res = await fetch(this.endpoint, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Goog-Api-Key": this.apiKey,
+        },
+        body: JSON.stringify(body),
+      });
+    } catch (e) {
+      throw new Error(`Stitch MCP network error (${toolName}): ${(e as Error).message}`);
+    }
+
+    if (!res.ok) {
+      const detail = await res.text().catch(() => "");
+      throw new Error(`Stitch MCP HTTP ${res.status} on tool "${toolName}": ${detail.slice(0, 300)}`);
+    }
+
+    const json = (await res.json()) as RpcResponse;
+
+    if (json.error) {
+      throw new Error(`Stitch MCP tool error (${toolName}): [${json.error.code}] ${json.error.message}`);
+    }
+
+    const text = json.result?.content?.[0]?.text;
+    if (typeof text !== "string" || text.length === 0) {
+      throw new Error(`Stitch MCP returned empty content for tool "${toolName}"`);
+    }
+
+    return text;
+  }
+
+  // ── High-level tool wrappers ──────────────────────────────────────────────
+
+  /**
+   * Creates a new Stitch project.
+   * Returns the bare numeric project ID (e.g. "4044680601076201931").
+   */
+  async createProject(title: string): Promise<string> {
+    const text = await this.call("create_project", { title });
+    return extractProjectId(text);
+  }
+
+  /**
+   * Generates a screen from a text prompt inside an existing project.
+   * Returns the bare screen ID (e.g. "98b50e2ddc9943efb387052637738f61").
+   *
+   * Schema-verified params (camelCase — confirmed via tools/list):
+   *   projectId, prompt, modelId, deviceType, designSystem
+   */
+  async generateScreen(
+    projectId: string,
+    prompt: string,
+    modelId: StitchModelId = "GEMINI_3_1_PRO"
+  ): Promise<string> {
+    const text = await this.call("generate_screen_from_text", {
+      projectId,
+      prompt,
+      modelId,
+      deviceType: "DESKTOP",
+    });
+    return extractScreenId(text);
+  }
+
+  /**
+   * Retrieves a screen and returns its HTML content.
+   *
+   * get_screen returns: { htmlCode: { downloadUrl: "https://..." }, ... }
+   * The HTML is not inline — must be fetched from downloadUrl.
+   *
+   * Stitch's HTML export can lag behind screen creation by several seconds.
+   * We poll until htmlCode is populated (up to MAX_RETRIES attempts).
+   */
+  async getScreen(projectId: string, screenId: string): Promise<string> {
+    const name = `projects/${projectId}/screens/${screenId}`;
+    const MAX_RETRIES = 8;
+    const RETRY_DELAY_MS = 5000;
+
+    for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+      const text = await this.call("get_screen", { name, projectId, screenId });
+
+      let screenObj: Record<string, unknown>;
+      try {
+        screenObj = JSON.parse(text) as Record<string, unknown>;
+      } catch {
+        const t = text.trim();
+        if (t.startsWith("<!DOCTYPE") || t.startsWith("<html")) return text;
+        throw new Error(`get_screen returned non-JSON for ${name}: ${text.slice(0, 200)}`);
+      }
+
+      const htmlCode = screenObj["htmlCode"] as
+        | string
+        | { downloadUrl?: string }
+        | Record<string, never>
+        | undefined;
+
+      // Inline HTML string
+      if (typeof htmlCode === "string" && htmlCode.trim().length > 0) {
+        return htmlCode;
+      }
+
+      // File reference with download URL
+      if (
+        htmlCode &&
+        typeof htmlCode === "object" &&
+        "downloadUrl" in htmlCode &&
+        typeof (htmlCode as { downloadUrl: string }).downloadUrl === "string"
+      ) {
+        return this.fetchDownloadUrl((htmlCode as { downloadUrl: string }).downloadUrl, name);
+      }
+
+      // Empty object {} — HTML export not ready yet; wait and retry
+      if (attempt < MAX_RETRIES) {
+        await sleep(RETRY_DELAY_MS);
+      }
+    }
+
+    throw new Error(
+      `get_screen htmlCode never populated for ${name} after ${MAX_RETRIES} attempts (${(MAX_RETRIES * RETRY_DELAY_MS) / 1000}s). ` +
+      "Stitch may still be processing — try again in a few seconds."
+    );
+  }
+
+  /** Fetches a Stitch-signed download URL and returns the text content. */
+  private async fetchDownloadUrl(url: string, context: string): Promise<string> {
+    let res: Response;
+    try {
+      res = await fetch(url);
+    } catch (e) {
+      throw new Error(`Failed to download HTML from Stitch for ${context}: ${(e as Error).message}`);
+    }
+    if (!res.ok) {
+      throw new Error(`Stitch download URL returned HTTP ${res.status} for ${context}`);
+    }
+    return res.text();
+  }
+}
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+// ─── Response parsers ─────────────────────────────────────────────────────────
+
+/**
+ * Extracts the bare numeric project ID from a create_project response.
+ *
+ * Google returns: { "name": "projects/12345", "title": "...", ... }
+ * We strip the "projects/" prefix — subsequent tools use the bare ID.
+ */
+function extractProjectId(text: string): string {
+  try {
+    const obj = JSON.parse(text) as Record<string, unknown>;
+    if (typeof obj["name"] === "string" && obj["name"].startsWith("projects/")) {
+      return (obj["name"] as string).slice("projects/".length);
+    }
+    for (const key of ["projectId", "project_id", "id"]) {
+      const val = obj[key];
+      if (typeof val === "string" && val.length > 0) return val as string;
+    }
+  } catch {}
+
+  const m = text.match(/projects\/([0-9]+)/);
+  if (m?.[1]) return m[1];
+
+  throw new Error(`Could not extract project ID from create_project response. Raw: ${text.slice(0, 300)}`);
+}
+
+/**
+ * Extracts the bare screen ID from a generate_screen_from_text response.
+ *
+ * Response may look like:
+ *   { "name": "projects/123/screens/abc123", ... }  → "abc123"
+ *   "screens/abc123"                                 → "abc123"
+ */
+function extractScreenId(text: string): string {
+  try {
+    const obj = JSON.parse(text) as Record<string, unknown>;
+    // Full resource name: "projects/123/screens/abc123"
+    if (typeof obj["name"] === "string") {
+      const m = (obj["name"] as string).match(/screens\/([0-9a-f]+)/i);
+      if (m?.[1]) return m[1];
+    }
+    for (const key of ["screenId", "screen_id", "id"]) {
+      const val = obj[key];
+      if (typeof val === "string" && val.length > 0) return val as string;
+    }
+  } catch {}
+
+  // Plain text: "screens/abc123" or just "abc123"
+  const m = text.match(/screens\/([0-9a-f]+)/i);
+  if (m?.[1]) return m[1];
+
+  // Bare hex string (32 chars)
+  const hex = text.trim();
+  if (/^[0-9a-f]{24,}$/i.test(hex)) return hex;
+
+  throw new Error(`Could not extract screen ID from generate_screen_from_text response. Raw: ${text.slice(0, 300)}`);
+}
+

--- a/framework/core/stitch-generator.ts
+++ b/framework/core/stitch-generator.ts
@@ -5,9 +5,12 @@
  * Flow (per run):
  *   1. Create a Stitch project for this business
  *   2. Generate one Stitch screen per blueprint page (sequential — Stitch rate limits)
- *   3. Call get_screen per screen to retrieve HTML (build_site not on official endpoint)
- *   4. Post-process each page (inject SEO meta + accessibility attributes)
- *   5. Write output to output/stitch-site/{route}/index.html
+ *   3. Fetch HTML per screen via get_screen
+ *   4. Post-process each page (inject SEO meta + base accessibility attributes)
+ *   5. Run SEO + A11y review agents → collect patches and findings
+ *   6. Apply patches (attribute-level fixes only)
+ *   7. Write final HTML to output/stitch-site/{route}/index.html
+ *   8. Generate output/reports/stitch-review-report.html
  *
  * Requires STITCH_API_KEY in the environment.
  * Optional: STITCH_MODEL ("GEMINI_3_1_PRO" | "GEMINI_3_FLASH", default: GEMINI_3_1_PRO)
@@ -18,13 +21,19 @@ import * as path from "path";
 import { StitchClient } from "./stitch-client.js";
 import { buildPagePrompt } from "./stitch-prompt-builder.js";
 import { postProcessPage } from "./stitch-post-processor.js";
+import { reviewSEO } from "../agents/stitch-seo.agent.js";
+import { reviewA11y } from "../agents/stitch-a11y.agent.js";
+import { applyPatches } from "./stitch-patcher.js";
+import { generateReviewReport } from "./stitch-review-reporter.js";
 import type { WebsiteBlueprint, PageDefinition } from "../schemas/blueprint.types.js";
+import type { PageReviewSummary } from "../agents/stitch-html-review.types.js";
 
 export interface StitchGeneratorResult {
   ok: boolean;
   pagesGenerated: number;
   outputDir: string;
   projectId: string;
+  reportPath: string;
   errors: string[];
   warnings: string[];
 }
@@ -39,6 +48,7 @@ export async function generateWithStitch(
   const log = onProgress ?? (() => {});
   const errors: string[] = [];
   const warnings: string[] = [];
+  const pageReviews: PageReviewSummary[] = [];
 
   // ── Validate env ────────────────────────────────────────────────────────────
   const apiKey = process.env.STITCH_API_KEY;
@@ -48,6 +58,7 @@ export async function generateWithStitch(
       pagesGenerated: 0,
       outputDir,
       projectId: "",
+      reportPath: "",
       errors: ["STITCH_API_KEY is not set — add it to your .env file"],
       warnings: [],
     };
@@ -71,13 +82,13 @@ export async function generateWithStitch(
       pagesGenerated: 0,
       outputDir,
       projectId: "",
+      reportPath: "",
       errors: [`Failed to create Stitch project: ${(e as Error).message}`],
       warnings: [],
     };
   }
 
   // ── Step 2: Generate one screen per page ────────────────────────────────────
-  // Sequential — Stitch generates with Gemini and may have per-project rate limits.
   const screenMap: Array<{ screenId: string; route: string; page: PageDefinition }> = [];
 
   for (const page of blueprint.pages) {
@@ -92,12 +103,11 @@ export async function generateWithStitch(
       const msg = `Screen generation failed for "${page.id}": ${(e as Error).message}`;
       errors.push(msg);
       log(`  ✗ ${msg}`);
-      // Non-fatal: skip this page, continue with the rest
     }
   }
 
   if (screenMap.length === 0) {
-    return { ok: false, pagesGenerated: 0, outputDir, projectId, errors, warnings };
+    return { ok: false, pagesGenerated: 0, outputDir, projectId, reportPath: "", errors, warnings };
   }
 
   if (screenMap.length < blueprint.pages.length) {
@@ -106,9 +116,7 @@ export async function generateWithStitch(
     );
   }
 
-  // ── Step 3, 4 & 5: Fetch HTML per screen, post-process, and write ──────────
-  // build_site is not available on the official endpoint — we call get_screen
-  // individually for each generated screen and retrieve its HTML content.
+  // ── Steps 3–7: Fetch → post-process → review → patch → write ────────────────
   let pagesGenerated = 0;
 
   for (const { screenId, route, page } of screenMap) {
@@ -124,19 +132,55 @@ export async function generateWithStitch(
       continue;
     }
 
-    const processed = postProcessPage(html, page, blueprint);
+    // Step 4: inject our SEO meta block and base a11y attributes
+    const postProcessed = postProcessPage(html, page, blueprint);
 
-    // "/" → index.html, "/about" → about/index.html
+    // Step 5: run review agents
+    log(`  Running SEO + A11y agents on "${page.id}"...`);
+    const seoResult  = reviewSEO(postProcessed, page, blueprint);
+    const a11yResult = reviewA11y(postProcessed, page, blueprint);
+
+    const allPatches  = [...seoResult.patches,  ...a11yResult.patches];
+    const allFindings = [...seoResult.findings, ...a11yResult.findings];
+
+    // Step 6: apply patches
+    const { html: patched, applied, skipped } = applyPatches(postProcessed, allPatches);
+
+    if (applied.length > 0) {
+      log(`  ✓ Patched ${applied.length} issue(s): ${applied.slice(0, 2).join("; ")}${applied.length > 2 ? ` (+${applied.length - 2} more)` : ""}`);
+    }
+    const manualCount = allFindings.filter(f => f.severity === "error" || f.severity === "warning").length;
+    if (manualCount > 0) {
+      log(`  ⚠  ${manualCount} finding(s) need manual review — see report`);
+    }
+
+    // Collect for report
+    pageReviews.push({
+      pageId: page.id,
+      route,
+      patchesApplied: applied,
+      patchesSkipped: skipped,
+      findings: allFindings,
+    });
+
+    // Step 7: write final HTML
     const relPath =
       route === "/" ? "index.html" : `${route.replace(/^\//, "").replace(/\/$/, "")}/index.html`;
 
     const fullPath = path.join(outputDir, relPath);
     fs.mkdirSync(path.dirname(fullPath), { recursive: true });
-    fs.writeFileSync(fullPath, processed, "utf-8");
+    fs.writeFileSync(fullPath, patched, "utf-8");
 
     pagesGenerated++;
     log(`  Wrote ${relPath}`);
   }
 
-  return { ok: pagesGenerated > 0, pagesGenerated, outputDir, projectId, errors, warnings };
+  // ── Step 8: Generate review report ─────────────────────────────────────────
+  let reportPath = "";
+  if (pageReviews.length > 0) {
+    reportPath = generateReviewReport(pageReviews, outputDir);
+    log(`Review report → ${path.relative(process.cwd(), reportPath)}`);
+  }
+
+  return { ok: pagesGenerated > 0, pagesGenerated, outputDir, projectId, reportPath, errors, warnings };
 }

--- a/framework/core/stitch-generator.ts
+++ b/framework/core/stitch-generator.ts
@@ -1,0 +1,142 @@
+/**
+ * stitch-generator — Drives the full Stitch code-generation flow for a
+ * multi-page website from a Stitchfy blueprint.
+ *
+ * Flow (per run):
+ *   1. Create a Stitch project for this business
+ *   2. Generate one Stitch screen per blueprint page (sequential — Stitch rate limits)
+ *   3. Call get_screen per screen to retrieve HTML (build_site not on official endpoint)
+ *   4. Post-process each page (inject SEO meta + accessibility attributes)
+ *   5. Write output to output/stitch-site/{route}/index.html
+ *
+ * Requires STITCH_API_KEY in the environment.
+ * Optional: STITCH_MODEL ("GEMINI_3_1_PRO" | "GEMINI_3_FLASH", default: GEMINI_3_1_PRO)
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { StitchClient } from "./stitch-client.js";
+import { buildPagePrompt } from "./stitch-prompt-builder.js";
+import { postProcessPage } from "./stitch-post-processor.js";
+import type { WebsiteBlueprint, PageDefinition } from "../schemas/blueprint.types.js";
+
+export interface StitchGeneratorResult {
+  ok: boolean;
+  pagesGenerated: number;
+  outputDir: string;
+  projectId: string;
+  errors: string[];
+  warnings: string[];
+}
+
+// ─── Entry point ──────────────────────────────────────────────────────────────
+
+export async function generateWithStitch(
+  blueprint: WebsiteBlueprint,
+  outputDir: string,
+  onProgress?: (message: string) => void
+): Promise<StitchGeneratorResult> {
+  const log = onProgress ?? (() => {});
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  // ── Validate env ────────────────────────────────────────────────────────────
+  const apiKey = process.env.STITCH_API_KEY;
+  if (!apiKey) {
+    return {
+      ok: false,
+      pagesGenerated: 0,
+      outputDir,
+      projectId: "",
+      errors: ["STITCH_API_KEY is not set — add it to your .env file"],
+      warnings: [],
+    };
+  }
+
+  const modelId =
+    (process.env.STITCH_MODEL as "GEMINI_3_1_PRO" | "GEMINI_3_FLASH") ?? "GEMINI_3_1_PRO";
+
+  const client = new StitchClient(apiKey);
+  fs.mkdirSync(outputDir, { recursive: true });
+
+  // ── Step 1: Create project ──────────────────────────────────────────────────
+  log(`Creating Stitch project for "${blueprint.business.name}"...`);
+  let projectId: string;
+  try {
+    projectId = await client.createProject(blueprint.business.name);
+    log(`Project created: ${projectId}`);
+  } catch (e) {
+    return {
+      ok: false,
+      pagesGenerated: 0,
+      outputDir,
+      projectId: "",
+      errors: [`Failed to create Stitch project: ${(e as Error).message}`],
+      warnings: [],
+    };
+  }
+
+  // ── Step 2: Generate one screen per page ────────────────────────────────────
+  // Sequential — Stitch generates with Gemini and may have per-project rate limits.
+  const screenMap: Array<{ screenId: string; route: string; page: PageDefinition }> = [];
+
+  for (const page of blueprint.pages) {
+    log(`Generating screen for page "${page.id}" (${page.path})...`);
+    const prompt = buildPagePrompt(page, blueprint);
+
+    try {
+      const screenId = await client.generateScreen(projectId, prompt, modelId);
+      screenMap.push({ screenId, route: page.path, page });
+      log(`  Screen ready: ${screenId}`);
+    } catch (e) {
+      const msg = `Screen generation failed for "${page.id}": ${(e as Error).message}`;
+      errors.push(msg);
+      log(`  ✗ ${msg}`);
+      // Non-fatal: skip this page, continue with the rest
+    }
+  }
+
+  if (screenMap.length === 0) {
+    return { ok: false, pagesGenerated: 0, outputDir, projectId, errors, warnings };
+  }
+
+  if (screenMap.length < blueprint.pages.length) {
+    warnings.push(
+      `${blueprint.pages.length - screenMap.length} page(s) skipped due to screen generation errors`
+    );
+  }
+
+  // ── Step 3, 4 & 5: Fetch HTML per screen, post-process, and write ──────────
+  // build_site is not available on the official endpoint — we call get_screen
+  // individually for each generated screen and retrieve its HTML content.
+  let pagesGenerated = 0;
+
+  for (const { screenId, route, page } of screenMap) {
+    log(`Fetching HTML for page "${page.id}" (screen: ${screenId})...`);
+
+    let html: string;
+    try {
+      html = await client.getScreen(projectId, screenId);
+    } catch (e) {
+      const msg = `Failed to fetch HTML for "${page.id}": ${(e as Error).message}`;
+      errors.push(msg);
+      log(`  ✗ ${msg}`);
+      continue;
+    }
+
+    const processed = postProcessPage(html, page, blueprint);
+
+    // "/" → index.html, "/about" → about/index.html
+    const relPath =
+      route === "/" ? "index.html" : `${route.replace(/^\//, "").replace(/\/$/, "")}/index.html`;
+
+    const fullPath = path.join(outputDir, relPath);
+    fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+    fs.writeFileSync(fullPath, processed, "utf-8");
+
+    pagesGenerated++;
+    log(`  Wrote ${relPath}`);
+  }
+
+  return { ok: pagesGenerated > 0, pagesGenerated, outputDir, projectId, errors, warnings };
+}

--- a/framework/core/stitch-patcher.ts
+++ b/framework/core/stitch-patcher.ts
@@ -1,0 +1,54 @@
+/**
+ * stitch-patcher — Applies a list of HtmlPatch operations to an HTML string.
+ *
+ * Each patch is a find-and-replace. Patches are applied sequentially so that
+ * later patches can see earlier ones' results. The return value records which
+ * patches matched (applied) and which didn't (skipped), so the reporter can
+ * show exactly what changed per page.
+ *
+ * Safety boundary: patches must be attribute-level only. This module enforces
+ * nothing about that — it's the agents' responsibility to stay within scope.
+ */
+
+import type { HtmlPatch } from "../agents/stitch-html-review.types.js";
+
+export interface PatchResult {
+  html: string;
+  applied: string[];
+  skipped: string[];
+}
+
+export function applyPatches(html: string, patches: HtmlPatch[]): PatchResult {
+  let result = html;
+  const applied: string[] = [];
+  const skipped: string[] = [];
+
+  for (const patch of patches) {
+    const before = result;
+
+    if (patch.find instanceof RegExp) {
+      const flags = patch.replaceAll
+        ? ensureGlobalFlag(patch.find)
+        : patch.find;
+      result = result.replace(flags, patch.replace);
+    } else {
+      // String find
+      result = patch.replaceAll
+        ? result.split(patch.find).join(patch.replace)
+        : result.replace(patch.find, patch.replace);
+    }
+
+    if (result !== before) {
+      applied.push(patch.description);
+    } else {
+      skipped.push(patch.description);
+    }
+  }
+
+  return { html: result, applied, skipped };
+}
+
+function ensureGlobalFlag(re: RegExp): RegExp {
+  if (re.flags.includes("g")) return re;
+  return new RegExp(re.source, re.flags + "g");
+}

--- a/framework/core/stitch-post-processor.ts
+++ b/framework/core/stitch-post-processor.ts
@@ -1,0 +1,162 @@
+/**
+ * stitch-post-processor — Injects Stitchfy's structured SEO and accessibility
+ * data into the raw HTML that Stitch's build_site tool returns.
+ *
+ * Stitch generates visual design; it knows nothing about the blueprint's
+ * seo.pageMeta, seo.openGraph, or accessibility.landmarkRequirements.
+ * This module bridges that gap before the HTML is written to disk.
+ *
+ * Operations (in order):
+ *   1. Strip any <title>/<meta charset>/<meta viewport>/<meta description>
+ *      that Stitch may have emitted, so we can replace them cleanly.
+ *   2. Inject our SEO meta block + JSON-LD into </head>.
+ *   3. Add <html lang="en"> if absent.
+ *   4. Inject skip-to-main-content link immediately after <body>.
+ *   5. Add id="main-content" to <main> if it exists and lacks an id.
+ */
+
+import type { PageDefinition, WebsiteBlueprint } from "../schemas/blueprint.types.js";
+
+export function postProcessPage(
+  html: string,
+  page: PageDefinition,
+  blueprint: WebsiteBlueprint
+): string {
+  const { seo, business } = blueprint;
+  const pageMeta = seo.pageMeta.find((m) => m.pageId === page.id);
+
+  const title = pageMeta?.title ?? `${page.title} | ${esc(business.name)}`;
+  const description = pageMeta?.description ?? seo.defaultMetaDescription;
+  const og = seo.openGraph;
+  const siteUrl = og["url"]?.replace(/\/$/, "") ?? "";
+
+  // ── Step 1: Remove Stitch-generated head tags we will replace ─────────────
+  let result = html
+    .replace(/<title>[^<]*<\/title>/gi, "")
+    .replace(/<meta\s+charset[^>]*>/gi, "")
+    .replace(/<meta\s+name=["']viewport["'][^>]*>/gi, "")
+    .replace(/<meta\s+name=["']description["'][^>]*>/gi, "");
+
+  // ── Step 2: Inject SEO meta block ─────────────────────────────────────────
+  const metaBlock = buildMetaBlock(title, description, og, siteUrl, page.path);
+  const jsonLd = page.id === "home" ? buildJsonLd(business, seo) : "";
+
+  const headInjection = [metaBlock, jsonLd].filter(Boolean).join("\n");
+
+  if (result.includes("</head>")) {
+    result = result.replace("</head>", `${headInjection}\n</head>`);
+  } else {
+    // Stitch returned a fragment without a proper <head> — wrap it
+    result = `<!DOCTYPE html>\n<html lang="en">\n<head>\n${headInjection}\n</head>\n<body>\n${result}\n</body>\n</html>`;
+  }
+
+  // ── Step 3: Ensure lang="en" on <html> ────────────────────────────────────
+  if (!/<html[^>]+lang=/i.test(result)) {
+    result = result.replace(/<html([^>]*)>/i, '<html$1 lang="en">');
+  }
+
+  // ── Step 4: Inject skip link immediately inside <body> ────────────────────
+  const skipLink = [
+    `<a`,
+    ` href="#main-content"`,
+    ` style="position:absolute;left:-9999px;width:1px;height:1px;overflow:hidden;z-index:9999"`,
+    ` onfocus="this.style.cssText='position:fixed;top:0;left:0;width:auto;height:auto;padding:0.5rem 1rem;background:#fff;color:#000;z-index:9999'"`,
+    ` onblur="this.style.cssText='position:absolute;left:-9999px;width:1px;height:1px;overflow:hidden;z-index:9999'"`,
+    `>Skip to main content</a>`,
+  ].join("");
+
+  result = result.replace(/<body([^>]*)>/i, `<body$1>\n${skipLink}`);
+
+  // ── Step 5: Add id="main-content" to <main> if missing ───────────────────
+  if (/<main(?![^>]*\bid=)[^>]*>/i.test(result)) {
+    result = result.replace(/<main([^>]*)>/i, '<main$1 id="main-content">');
+  }
+
+  return result;
+}
+
+// ─── Builders ────────────────────────────────────────────────────────────────
+
+function buildMetaBlock(
+  title: string,
+  description: string,
+  og: Record<string, string>,
+  siteUrl: string,
+  pagePath: string
+): string {
+  const canonical = `${siteUrl}${pagePath}`;
+  const rows: string[] = [
+    `  <meta charset="UTF-8">`,
+    `  <meta name="viewport" content="width=device-width, initial-scale=1">`,
+    `  <title>${esc(title)}</title>`,
+    `  <meta name="description" content="${esc(description)}">`,
+    `  <link rel="canonical" href="${esc(canonical)}">`,
+    // Open Graph
+    `  <meta property="og:type" content="${esc(og["type"] ?? "website")}">`,
+    `  <meta property="og:title" content="${esc(title)}">`,
+    `  <meta property="og:description" content="${esc(description)}">`,
+    `  <meta property="og:url" content="${esc(canonical)}">`,
+  ];
+
+  if (og["image"]) {
+    rows.push(`  <meta property="og:image" content="${esc(og["image"])}">`);
+  }
+  if (og["site_name"]) {
+    rows.push(`  <meta property="og:site_name" content="${esc(og["site_name"])}">`);
+  }
+
+  // Twitter Card
+  rows.push(
+    `  <meta name="twitter:card" content="summary_large_image">`,
+    `  <meta name="twitter:title" content="${esc(title)}">`,
+    `  <meta name="twitter:description" content="${esc(description)}">`
+  );
+  if (og["image"]) {
+    rows.push(`  <meta name="twitter:image" content="${esc(og["image"])}">`);
+  }
+
+  return rows.join("\n");
+}
+
+function buildJsonLd(
+  business: WebsiteBlueprint["business"],
+  seo: WebsiteBlueprint["seo"]
+): string {
+  const ld: Record<string, unknown> = {
+    "@context": "https://schema.org",
+    "@type": "LocalBusiness",
+    name: business.name,
+    description: business.description,
+    url: seo.openGraph["url"] ?? "",
+    telephone: business.phone,
+    email: business.email,
+    address: {
+      "@type": "PostalAddress",
+      streetAddress: business.address,
+    },
+  };
+
+  const hours = Object.entries(business.operatingHours);
+  if (hours.length > 0) {
+    ld["openingHoursSpecification"] = hours.map(([day, range]) => {
+      const [opens, closes] = range.split(/[–\-]/).map((s) => s.trim());
+      return { "@type": "OpeningHoursSpecification", dayOfWeek: day, opens, closes };
+    });
+  }
+
+  const socials = Object.values(business.socialLinks).filter(Boolean);
+  if (socials.length > 0) {
+    ld["sameAs"] = socials;
+  }
+
+  return `  <script type="application/ld+json">\n  ${JSON.stringify(ld, null, 2).replace(/\n/g, "\n  ")}\n  </script>`;
+}
+
+// Minimal HTML attribute escaping
+function esc(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}

--- a/framework/core/stitch-post-processor.ts
+++ b/framework/core/stitch-post-processor.ts
@@ -33,9 +33,19 @@ export function postProcessPage(
   // ── Step 1: Remove Stitch-generated head tags we will replace ─────────────
   let result = html
     .replace(/<title>[^<]*<\/title>/gi, "")
-    .replace(/<meta\s+charset[^>]*>/gi, "")
-    .replace(/<meta\s+name=["']viewport["'][^>]*>/gi, "")
-    .replace(/<meta\s+name=["']description["'][^>]*>/gi, "");
+    .replace(/<meta\s[^>]*?\bcharset\b[^>]*>/gi, "")
+    .replace(/<meta\s[^>]*?\bname=["']viewport["'][^>]*>/gi, "")
+    .replace(/<meta\s[^>]*?\bname=["']description["'][^>]*>/gi, "");
+
+  // Remove duplicate <link> tags (Stitch occasionally emits the same stylesheet twice)
+  const seenLinkHrefs = new Set<string>();
+  result = result.replace(/<link([^>]*)>/gi, (match, attrs: string) => {
+    const m = attrs.match(/href=["']([^"']+)["']/);
+    if (!m) return match;
+    if (seenLinkHrefs.has(m[1])) return "";
+    seenLinkHrefs.add(m[1]);
+    return match;
+  });
 
   // ── Step 2: Inject SEO meta block ─────────────────────────────────────────
   const metaBlock = buildMetaBlock(title, description, og, siteUrl, page.path);

--- a/framework/core/stitch-prompt-builder.ts
+++ b/framework/core/stitch-prompt-builder.ts
@@ -1,0 +1,129 @@
+/**
+ * stitch-prompt-builder — Converts blueprint data into a per-page text prompt
+ * for the Stitch generate_screen_from_text MCP tool.
+ *
+ * Every prompt starts with an explicit design-system block (exact hex colors,
+ * fonts, nav links) so that Stitch stays consistent across all generated pages.
+ */
+
+import type { PageDefinition, WebsiteBlueprint } from "../schemas/blueprint.types.js";
+
+export function buildPagePrompt(page: PageDefinition, blueprint: WebsiteBlueprint): string {
+  const { business, ux, seo } = blueprint;
+
+  const pageMeta = seo.pageMeta.find((m) => m.pageId === page.id);
+
+  const navList = ux.navigation
+    .map((n) => `  • ${n.label} → ${n.href}${n.external ? " (external)" : ""}`)
+    .join("\n");
+
+  const hoursList = Object.entries(business.operatingHours)
+    .map(([day, hrs]) => `  ${day}: ${hrs}`)
+    .join("\n");
+
+  const socialList = Object.entries(business.socialLinks)
+    .map(([platform, handle]) => `  ${platform}: ${handle}`)
+    .join("\n");
+
+  const lines: string[] = [
+    `Design the "${page.title}" page for ${business.name}, a ${business.industry} business located in ${business.location || business.address}.`,
+    "",
+    // ── Design system block ─────────────────────────────────────────────────
+    "=== DESIGN SYSTEM — use these exact values, no substitutions ===",
+    "Colors:",
+    `  Primary:    ${ux.colorPalette.primary}`,
+    `  Secondary:  ${ux.colorPalette.secondary}`,
+    `  Accent:     ${ux.colorPalette.accent}`,
+    `  Text:       ${ux.colorPalette.text}`,
+    `  Background: ${ux.colorPalette.background}`,
+    `  Border:     ${ux.colorPalette.border}`,
+    "Typography:",
+    `  Heading font:   ${ux.typography.headingFont} (weight: ${ux.typography.headingWeight})`,
+    `  Body font:      ${ux.typography.bodyFont}`,
+    `  Base font size: ${ux.typography.scaleBase}`,
+    "",
+    // ── Shared layout ───────────────────────────────────────────────────────
+    "=== SHARED LAYOUT (identical across all pages) ===",
+    "Sticky header containing:",
+    `  • Logo / business name: ${business.name}`,
+    `  • Navigation links:\n${navList}`,
+    `  • Phone number: ${business.phone}`,
+    `  • CTA button: "${ux.header.ctaLabel}" → ${ux.header.ctaHref}`,
+    "Footer containing:",
+    `  • Columns: ${ux.footer.columns.join(", ")}`,
+    `  • Address: ${business.address}`,
+    `  • Hours summary`,
+    `  • Social links${socialList ? `:\n${socialList}` : ": none"}`,
+    `  • Legal note: ${ux.footer.legalNote || `© ${new Date().getFullYear()} ${business.name}`}`,
+    "",
+    // ── Business information ────────────────────────────────────────────────
+    "=== BUSINESS INFORMATION ===",
+    `Name:        ${business.name}`,
+    `Industry:    ${business.industry}`,
+    `Description: ${business.description}`,
+    `Phone:       ${business.phone}`,
+    `Email:       ${business.email}`,
+    `Address:     ${business.address}`,
+    `Booking:     ${business.booking}`,
+    `Services:    ${business.services.join(", ")}`,
+    "Hours:",
+    hoursList,
+    "",
+    // ── This specific page ──────────────────────────────────────────────────
+    "=== THIS PAGE ===",
+    `Title:   ${page.title}`,
+    `Route:   ${page.path}`,
+    `Purpose: ${page.purpose}`,
+    `Sections to render (in this exact order): ${page.sections.join(", ")}`,
+  ];
+
+  if (page.primaryCTA) {
+    lines.push(`Primary CTA:   "${page.primaryCTA.label}" → ${page.primaryCTA.href}`);
+  }
+  if (page.secondaryCTA) {
+    lines.push(`Secondary CTA: "${page.secondaryCTA.label}" → ${page.secondaryCTA.href}`);
+  }
+  if (page.requiredContent.length > 0) {
+    lines.push(`Required content on this page: ${page.requiredContent.join(", ")}`);
+  }
+  if (pageMeta?.description) {
+    lines.push(`Meta description (place in <meta name="description">): "${pageMeta.description}"`);
+  }
+
+  // Hero style — only relevant for home page but harmless if included elsewhere
+  if (page.id === "home") {
+    lines.push("", "=== HERO VISUAL SPEC ===");
+    const h = ux.heroStyle;
+    if (h.backgroundType === "gradient") {
+      lines.push(
+        `Background: CSS linear-gradient from ${h.gradientFrom} to ${h.gradientTo}`,
+        `Text color: ${h.textColor} (must pass WCAG AA contrast against the gradient)`
+      );
+    } else if (h.backgroundType === "solid") {
+      lines.push(
+        `Background: solid ${h.backgroundColor}`,
+        `Text color: ${h.textColor}`
+      );
+    } else {
+      lines.push(
+        `Background: full-width image with overlay opacity ${h.overlayOpacity ?? 0.5}`,
+        `Text color: ${h.textColor}`
+      );
+    }
+  }
+
+  lines.push(
+    "",
+    // ── Hard requirements ───────────────────────────────────────────────────
+    "=== REQUIREMENTS ===",
+    "- Desktop-first, fully responsive",
+    "- Semantic HTML5: proper heading hierarchy, one <h1> per page",
+    "- WCAG 2.1 AA: use the exact hex colors above — do not substitute",
+    "- All navigation links must use the exact routes listed above",
+    "- No placeholder lorem ipsum — use the actual business information provided",
+    "- Include <html lang=\"en\"> on the root element",
+    "- Do not include <title> or <meta> tags — those will be injected separately",
+  );
+
+  return lines.join("\n");
+}

--- a/framework/core/stitch-review-reporter.ts
+++ b/framework/core/stitch-review-reporter.ts
@@ -1,0 +1,144 @@
+/**
+ * stitch-review-reporter — Generates output/reports/stitch-review-report.html
+ *
+ * Produces one self-contained HTML report per pipeline run showing:
+ *   - Per-page: patches auto-applied, findings requiring manual action
+ *   - Severity badges (error / warning / info)
+ *   - Overall summary counts
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import type { PageReviewSummary, FindingSeverity } from "../agents/stitch-html-review.types.js";
+
+export function generateReviewReport(
+  pages: PageReviewSummary[],
+  outputDir: string
+): string {
+  const reportsDir = path.join(outputDir, "..", "reports");
+  fs.mkdirSync(reportsDir, { recursive: true });
+
+  const reportPath = path.join(reportsDir, "stitch-review-report.html");
+  fs.writeFileSync(reportPath, buildHtml(pages), "utf-8");
+  return reportPath;
+}
+
+// ─── HTML builder ─────────────────────────────────────────────────────────────
+
+function buildHtml(pages: PageReviewSummary[]): string {
+  const totalPatches = pages.reduce((n, p) => n + p.patchesApplied.length, 0);
+  const totalErrors   = pages.reduce((n, p) => n + p.findings.filter(f => f.severity === "error").length, 0);
+  const totalWarnings = pages.reduce((n, p) => n + p.findings.filter(f => f.severity === "warning").length, 0);
+  const totalInfo     = pages.reduce((n, p) => n + p.findings.filter(f => f.severity === "info").length, 0);
+  const generatedAt   = new Date().toLocaleString();
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Stitch Review Report</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: #f8f9fa; color: #1a1a2e; line-height: 1.6; }
+  .header { background: linear-gradient(135deg, #b30069 0%, #7a004a 100%); color: #fff; padding: 2rem 2.5rem; }
+  .header h1 { font-size: 1.6rem; font-weight: 700; }
+  .header p  { font-size: 0.875rem; opacity: .8; margin-top: .25rem; }
+  .summary { display: flex; gap: 1rem; padding: 1.5rem 2.5rem; background: #fff; border-bottom: 1px solid #e5e7eb; flex-wrap: wrap; }
+  .stat { background: #f3f4f6; border-radius: 8px; padding: .75rem 1.25rem; min-width: 130px; text-align: center; }
+  .stat .num { font-size: 1.75rem; font-weight: 700; }
+  .stat .lbl { font-size: .75rem; color: #6b7280; text-transform: uppercase; letter-spacing: .05em; }
+  .stat.green .num { color: #059669; }
+  .stat.red   .num { color: #dc2626; }
+  .stat.amber .num { color: #d97706; }
+  .stat.blue  .num { color: #2563eb; }
+  .content { max-width: 960px; margin: 2rem auto; padding: 0 1.5rem 3rem; }
+  .page-card { background: #fff; border-radius: 10px; border: 1px solid #e5e7eb; margin-bottom: 1.5rem; overflow: hidden; }
+  .page-header { background: #f9fafb; border-bottom: 1px solid #e5e7eb; padding: .9rem 1.25rem; display: flex; align-items: center; justify-content: space-between; }
+  .page-title { font-weight: 700; font-size: 1rem; }
+  .page-route { font-size: .8rem; color: #6b7280; background: #e5e7eb; border-radius: 4px; padding: .15rem .5rem; font-family: monospace; }
+  .page-body { padding: 1.25rem; }
+  .section-label { font-size: .7rem; font-weight: 700; text-transform: uppercase; letter-spacing: .08em; color: #6b7280; margin-bottom: .6rem; margin-top: 1rem; }
+  .section-label:first-child { margin-top: 0; }
+  .patch-list, .finding-list { list-style: none; display: flex; flex-direction: column; gap: .4rem; }
+  .patch-item { display: flex; align-items: flex-start; gap: .5rem; font-size: .875rem; }
+  .patch-item::before { content: "✓"; color: #059669; font-weight: 700; flex-shrink: 0; margin-top: .05rem; }
+  .patch-skipped::before { content: "–"; color: #9ca3af; }
+  .finding-item { border-radius: 6px; padding: .6rem .9rem; font-size: .875rem; border-left: 4px solid; }
+  .finding-error   { background: #fef2f2; border-color: #dc2626; }
+  .finding-warning { background: #fffbeb; border-color: #d97706; }
+  .finding-info    { background: #eff6ff; border-color: #2563eb; }
+  .badge { display: inline-block; border-radius: 4px; padding: .15rem .45rem; font-size: .7rem; font-weight: 700; text-transform: uppercase; letter-spacing: .04em; margin-right: .4rem; }
+  .badge-error   { background: #fee2e2; color: #b91c1c; }
+  .badge-warning { background: #fef3c7; color: #92400e; }
+  .badge-info    { background: #dbeafe; color: #1e40af; }
+  .badge-seo  { background: #f3e8ff; color: #7c3aed; }
+  .badge-a11y { background: #ecfdf5; color: #065f46; }
+  .rec { margin-top: .3rem; font-size: .8rem; color: #4b5563; }
+  .empty { color: #9ca3af; font-size: .875rem; font-style: italic; }
+  .disclaimer { margin-top: 2rem; padding: 1rem 1.25rem; background: #fff; border: 1px solid #e5e7eb; border-radius: 8px; font-size: .8rem; color: #6b7280; }
+</style>
+</head>
+<body>
+<div class="header">
+  <h1>Stitchfy · Stitch Review Report</h1>
+  <p>Generated ${generatedAt} · ${pages.length} page(s) reviewed</p>
+</div>
+<div class="summary">
+  <div class="stat green"><div class="num">${totalPatches}</div><div class="lbl">Auto-patched</div></div>
+  <div class="stat red">  <div class="num">${totalErrors}</div>  <div class="lbl">Errors</div></div>
+  <div class="stat amber"><div class="num">${totalWarnings}</div><div class="lbl">Warnings</div></div>
+  <div class="stat blue"> <div class="num">${totalInfo}</div>   <div class="lbl">Info</div></div>
+</div>
+<div class="content">
+${pages.map(renderPageCard).join("\n")}
+<div class="disclaimer">
+  <strong>Note:</strong> Auto-patches are attribute-level only (aria-label, alt, aria-hidden, JSON-LD rewrite).
+  No structural changes were made. Findings marked <em>error</em> or <em>warning</em> require human review
+  before deploying to production. This report does not constitute a full WCAG or legal compliance audit.
+</div>
+</div>
+</body>
+</html>`;
+}
+
+function renderPageCard(page: PageReviewSummary): string {
+  const errors   = page.findings.filter(f => f.severity === "error");
+  const warnings = page.findings.filter(f => f.severity === "warning");
+  const infos    = page.findings.filter(f => f.severity === "info");
+
+  const patchesHtml = page.patchesApplied.length > 0
+    ? `<ul class="patch-list">${page.patchesApplied.map(d => `<li class="patch-item">${esc(d)}</li>`).join("")}</ul>`
+    : `<p class="empty">No patches needed — Stitch output was clean for this page.</p>`;
+
+  const findingsHtml = page.findings.length > 0
+    ? [...errors, ...warnings, ...infos].map(renderFinding).join("")
+    : `<p class="empty">No manual findings — this page is ready to deploy.</p>`;
+
+  return `<div class="page-card">
+  <div class="page-header">
+    <span class="page-title">${esc(page.pageId)}</span>
+    <span class="page-route">${esc(page.route)}</span>
+  </div>
+  <div class="page-body">
+    <div class="section-label">Auto-patched (${page.patchesApplied.length})</div>
+    ${patchesHtml}
+    <div class="section-label">Manual review required (${page.findings.length})</div>
+    ${findingsHtml}
+  </div>
+</div>`;
+}
+
+function renderFinding(f: { severity: FindingSeverity; category: string; rule: string; description: string; recommendation: string }): string {
+  return `<div class="finding-item finding-${f.severity}">
+  <span class="badge badge-${f.severity}">${f.severity}</span>
+  <span class="badge badge-${f.category}">${f.category}</span>
+  <strong>${esc(f.rule)}</strong><br>
+  ${esc(f.description)}
+  <div class="rec">→ ${esc(f.recommendation)}</div>
+</div>`;
+}
+
+function esc(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}

--- a/output/reports/accessibility-report.html
+++ b/output/reports/accessibility-report.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Accessibility Report — Luxe Beauty Studio</title>
+  <title>Accessibility Report — Glow &amp; Go Beauty Bar</title>
   <style>
     *, *::before, *::after { box-sizing: border-box; }
     body { font-family: system-ui, -apple-system, sans-serif; margin: 0; color: #1a1a1a; background: #f8f8f6; line-height: 1.55; font-size: 15px; }
@@ -35,9 +35,9 @@
 
     <div class="report-header">
   <h1>Accessibility Report</h1>
-  <p class="business">Luxe Beauty Studio</p>
+  <p class="business">Glow &amp; Go Beauty Bar</p>
   <div class="meta">
-    <span>Generated: Jun 15, 2026, 2:03 PM</span>
+    <span>Generated: Jun 20, 2026, 11:02 PM</span>
     <span>Framework: Stitchfy v2</span>
     <span>Blueprint: output/blueprint/website-blueprint.v1.json</span>
   </div>
@@ -58,7 +58,7 @@
   </div>
       <div class="card">
     <div class="card-label">Pages Reviewed</div>
-    <div class="card-value" style="">6</div>
+    <div class="card-value" style="">4</div>
   </div>
       <div class="card">
     <div class="card-label">Checklist Items</div>
@@ -66,11 +66,11 @@
   </div>
       <div class="card">
     <div class="card-label">HTML Checks Passed</div>
-    <div class="card-value" style="">78</div>
+    <div class="card-value" style="">26</div>
   </div>
       <div class="card">
     <div class="card-label">Warnings</div>
-    <div class="card-value" style="">6</div>
+    <div class="card-value" style="">2</div>
   </div>
       <div class="card">
     <div class="card-label">Status</div>
@@ -366,300 +366,6 @@
           <td style="opacity:0.7; font-size:0.85rem"></td>
         </tr>
 <tr>
-          <td>Services</td>
-          <td><code>lang-attribute</code></td>
-          <td>HTML lang attribute present</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem"></td>
-        </tr>
-<tr>
-          <td>Services</td>
-          <td><code>page-title</code></td>
-          <td>Page has a descriptive title</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem">&quot;Services | Luxe Beauty Studio | Luxe Beauty Studio&quot;</td>
-        </tr>
-<tr>
-          <td>Services</td>
-          <td><code>meta-description</code></td>
-          <td>Meta description present</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem">Check that content is non-empty and ≤ 160 characters</td>
-        </tr>
-<tr>
-          <td>Services</td>
-          <td><code>one-h1</code></td>
-          <td>Page has exactly one H1</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem">Found 1 H1 element</td>
-        </tr>
-<tr>
-          <td>Services</td>
-          <td><code>skip-link</code></td>
-          <td>Skip-to-content link targets #main-content</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem"></td>
-        </tr>
-<tr>
-          <td>Services</td>
-          <td><code>landmark-main</code></td>
-          <td>&lt;main id='main-content'&gt; landmark present</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem"></td>
-        </tr>
-<tr>
-          <td>Services</td>
-          <td><code>landmark-banner</code></td>
-          <td>&lt;header role='banner'&gt; present</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem"></td>
-        </tr>
-<tr>
-          <td>Services</td>
-          <td><code>landmark-contentinfo</code></td>
-          <td>&lt;footer role='contentinfo'&gt; present</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem"></td>
-        </tr>
-<tr>
-          <td>Services</td>
-          <td><code>landmark-navigation</code></td>
-          <td>&lt;nav&gt; has aria-label</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem"></td>
-        </tr>
-<tr>
-          <td>Services</td>
-          <td><code>image-alt-text</code></td>
-          <td>All &lt;img&gt; elements have alt attributes</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem"></td>
-        </tr>
-<tr>
-          <td>Services</td>
-          <td><code>phone-tel-link</code></td>
-          <td>Phone numbers wrapped in tel: links</td>
-          <td><span class="badge" style="background:#e67e22">⚠ WARN</span></td>
-          <td style="opacity:0.7; font-size:0.85rem">10 phone number(s), 2 tel: link(s)</td>
-        </tr>
-<tr>
-          <td>Services</td>
-          <td><code>address-element</code></td>
-          <td>&lt;address&gt; element used for physical address</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem"></td>
-        </tr>
-<tr>
-          <td>Services</td>
-          <td><code>focus-visible</code></td>
-          <td>Focus outline not suppressed without replacement</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem"></td>
-        </tr>
-<tr>
-          <td>Services</td>
-          <td><code>canonical</code></td>
-          <td>Canonical link tag present</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem"></td>
-        </tr>
-<tr>
-          <td>Gallery</td>
-          <td><code>lang-attribute</code></td>
-          <td>HTML lang attribute present</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem"></td>
-        </tr>
-<tr>
-          <td>Gallery</td>
-          <td><code>page-title</code></td>
-          <td>Page has a descriptive title</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem">&quot;Gallery | Luxe Beauty Studio | Luxe Beauty Studio&quot;</td>
-        </tr>
-<tr>
-          <td>Gallery</td>
-          <td><code>meta-description</code></td>
-          <td>Meta description present</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem">Check that content is non-empty and ≤ 160 characters</td>
-        </tr>
-<tr>
-          <td>Gallery</td>
-          <td><code>one-h1</code></td>
-          <td>Page has exactly one H1</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem">Found 1 H1 element</td>
-        </tr>
-<tr>
-          <td>Gallery</td>
-          <td><code>skip-link</code></td>
-          <td>Skip-to-content link targets #main-content</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem"></td>
-        </tr>
-<tr>
-          <td>Gallery</td>
-          <td><code>landmark-main</code></td>
-          <td>&lt;main id='main-content'&gt; landmark present</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem"></td>
-        </tr>
-<tr>
-          <td>Gallery</td>
-          <td><code>landmark-banner</code></td>
-          <td>&lt;header role='banner'&gt; present</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem"></td>
-        </tr>
-<tr>
-          <td>Gallery</td>
-          <td><code>landmark-contentinfo</code></td>
-          <td>&lt;footer role='contentinfo'&gt; present</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem"></td>
-        </tr>
-<tr>
-          <td>Gallery</td>
-          <td><code>landmark-navigation</code></td>
-          <td>&lt;nav&gt; has aria-label</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem"></td>
-        </tr>
-<tr>
-          <td>Gallery</td>
-          <td><code>image-alt-text</code></td>
-          <td>All &lt;img&gt; elements have alt attributes</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem"></td>
-        </tr>
-<tr>
-          <td>Gallery</td>
-          <td><code>phone-tel-link</code></td>
-          <td>Phone numbers wrapped in tel: links</td>
-          <td><span class="badge" style="background:#e67e22">⚠ WARN</span></td>
-          <td style="opacity:0.7; font-size:0.85rem">10 phone number(s), 2 tel: link(s)</td>
-        </tr>
-<tr>
-          <td>Gallery</td>
-          <td><code>address-element</code></td>
-          <td>&lt;address&gt; element used for physical address</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem"></td>
-        </tr>
-<tr>
-          <td>Gallery</td>
-          <td><code>focus-visible</code></td>
-          <td>Focus outline not suppressed without replacement</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem"></td>
-        </tr>
-<tr>
-          <td>Gallery</td>
-          <td><code>canonical</code></td>
-          <td>Canonical link tag present</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem"></td>
-        </tr>
-<tr>
-          <td>About Us</td>
-          <td><code>lang-attribute</code></td>
-          <td>HTML lang attribute present</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem"></td>
-        </tr>
-<tr>
-          <td>About Us</td>
-          <td><code>page-title</code></td>
-          <td>Page has a descriptive title</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem">&quot;About Us | Luxe Beauty Studio | Luxe Beauty Studio&quot;</td>
-        </tr>
-<tr>
-          <td>About Us</td>
-          <td><code>meta-description</code></td>
-          <td>Meta description present</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem">Check that content is non-empty and ≤ 160 characters</td>
-        </tr>
-<tr>
-          <td>About Us</td>
-          <td><code>one-h1</code></td>
-          <td>Page has exactly one H1</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem">Found 1 H1 element</td>
-        </tr>
-<tr>
-          <td>About Us</td>
-          <td><code>skip-link</code></td>
-          <td>Skip-to-content link targets #main-content</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem"></td>
-        </tr>
-<tr>
-          <td>About Us</td>
-          <td><code>landmark-main</code></td>
-          <td>&lt;main id='main-content'&gt; landmark present</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem"></td>
-        </tr>
-<tr>
-          <td>About Us</td>
-          <td><code>landmark-banner</code></td>
-          <td>&lt;header role='banner'&gt; present</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem"></td>
-        </tr>
-<tr>
-          <td>About Us</td>
-          <td><code>landmark-contentinfo</code></td>
-          <td>&lt;footer role='contentinfo'&gt; present</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem"></td>
-        </tr>
-<tr>
-          <td>About Us</td>
-          <td><code>landmark-navigation</code></td>
-          <td>&lt;nav&gt; has aria-label</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem"></td>
-        </tr>
-<tr>
-          <td>About Us</td>
-          <td><code>image-alt-text</code></td>
-          <td>All &lt;img&gt; elements have alt attributes</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem"></td>
-        </tr>
-<tr>
-          <td>About Us</td>
-          <td><code>phone-tel-link</code></td>
-          <td>Phone numbers wrapped in tel: links</td>
-          <td><span class="badge" style="background:#e67e22">⚠ WARN</span></td>
-          <td style="opacity:0.7; font-size:0.85rem">12 phone number(s), 3 tel: link(s)</td>
-        </tr>
-<tr>
-          <td>About Us</td>
-          <td><code>address-element</code></td>
-          <td>&lt;address&gt; element used for physical address</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem"></td>
-        </tr>
-<tr>
-          <td>About Us</td>
-          <td><code>focus-visible</code></td>
-          <td>Focus outline not suppressed without replacement</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem"></td>
-        </tr>
-<tr>
-          <td>About Us</td>
-          <td><code>canonical</code></td>
-          <td>Canonical link tag present</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem"></td>
-        </tr>
-<tr>
           <td>Contact</td>
           <td><code>lang-attribute</code></td>
           <td>HTML lang attribute present</td>
@@ -756,104 +462,6 @@
           <td>Canonical link tag present</td>
           <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
           <td style="opacity:0.7; font-size:0.85rem"></td>
-        </tr>
-<tr>
-          <td>Book Online</td>
-          <td><code>lang-attribute</code></td>
-          <td>HTML lang attribute present</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem"></td>
-        </tr>
-<tr>
-          <td>Book Online</td>
-          <td><code>page-title</code></td>
-          <td>Page has a descriptive title</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem">&quot;Book Online | Luxe Beauty Studio | Luxe Beauty Studio&quot;</td>
-        </tr>
-<tr>
-          <td>Book Online</td>
-          <td><code>meta-description</code></td>
-          <td>Meta description present</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem">Check that content is non-empty and ≤ 160 characters</td>
-        </tr>
-<tr>
-          <td>Book Online</td>
-          <td><code>one-h1</code></td>
-          <td>Page has exactly one H1</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem">Found 1 H1 element</td>
-        </tr>
-<tr>
-          <td>Book Online</td>
-          <td><code>skip-link</code></td>
-          <td>Skip-to-content link targets #main-content</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem"></td>
-        </tr>
-<tr>
-          <td>Book Online</td>
-          <td><code>landmark-main</code></td>
-          <td>&lt;main id='main-content'&gt; landmark present</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem"></td>
-        </tr>
-<tr>
-          <td>Book Online</td>
-          <td><code>landmark-banner</code></td>
-          <td>&lt;header role='banner'&gt; present</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem"></td>
-        </tr>
-<tr>
-          <td>Book Online</td>
-          <td><code>landmark-contentinfo</code></td>
-          <td>&lt;footer role='contentinfo'&gt; present</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem"></td>
-        </tr>
-<tr>
-          <td>Book Online</td>
-          <td><code>landmark-navigation</code></td>
-          <td>&lt;nav&gt; has aria-label</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem"></td>
-        </tr>
-<tr>
-          <td>Book Online</td>
-          <td><code>image-alt-text</code></td>
-          <td>All &lt;img&gt; elements have alt attributes</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem"></td>
-        </tr>
-<tr>
-          <td>Book Online</td>
-          <td><code>phone-tel-link</code></td>
-          <td>Phone numbers wrapped in tel: links</td>
-          <td><span class="badge" style="background:#e67e22">⚠ WARN</span></td>
-          <td style="opacity:0.7; font-size:0.85rem">12 phone number(s), 3 tel: link(s)</td>
-        </tr>
-<tr>
-          <td>Book Online</td>
-          <td><code>address-element</code></td>
-          <td>&lt;address&gt; element used for physical address</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem"></td>
-        </tr>
-<tr>
-          <td>Book Online</td>
-          <td><code>focus-visible</code></td>
-          <td>Focus outline not suppressed without replacement</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem"></td>
-        </tr>
-<tr>
-          <td>Book Online</td>
-          <td><code>canonical</code></td>
-          <td>Canonical link tag present</td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-          <td style="opacity:0.7; font-size:0.85rem"></td>
         </tr></tbody>
     </table>
 
@@ -866,28 +474,18 @@
           <td><span class="badge" style="background:#27ae60">✓ PASS</span> 13 &nbsp; <span class="badge" style="background:#e67e22">⚠ WARN</span> 1 &nbsp;  0</td>
         </tr>
 <tr>
-          <td><a href="/services">Services</a></td>
-          <td><code>/services</code></td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span> 13 &nbsp; <span class="badge" style="background:#e67e22">⚠ WARN</span> 1 &nbsp;  0</td>
+          <td><a href="/services-pricing">Services &amp; Pricing</a></td>
+          <td><code>/services-pricing</code></td>
+          <td><span class="badge" style="background:#27ae60">✓ PASS</span> 0 &nbsp; <span class="badge" style="background:#e67e22">⚠ WARN</span> 0 &nbsp;  0</td>
         </tr>
 <tr>
-          <td><a href="/gallery">Gallery</a></td>
-          <td><code>/gallery</code></td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span> 13 &nbsp; <span class="badge" style="background:#e67e22">⚠ WARN</span> 1 &nbsp;  0</td>
-        </tr>
-<tr>
-          <td><a href="/about">About Us</a></td>
-          <td><code>/about</code></td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span> 13 &nbsp; <span class="badge" style="background:#e67e22">⚠ WARN</span> 1 &nbsp;  0</td>
+          <td><a href="/book-now">Book Now</a></td>
+          <td><code>/book-now</code></td>
+          <td><span class="badge" style="background:#27ae60">✓ PASS</span> 0 &nbsp; <span class="badge" style="background:#e67e22">⚠ WARN</span> 0 &nbsp;  0</td>
         </tr>
 <tr>
           <td><a href="/contact">Contact</a></td>
           <td><code>/contact</code></td>
-          <td><span class="badge" style="background:#27ae60">✓ PASS</span> 13 &nbsp; <span class="badge" style="background:#e67e22">⚠ WARN</span> 1 &nbsp;  0</td>
-        </tr>
-<tr>
-          <td><a href="/book">Book Online</a></td>
-          <td><code>/book</code></td>
           <td><span class="badge" style="background:#27ae60">✓ PASS</span> 13 &nbsp; <span class="badge" style="background:#e67e22">⚠ WARN</span> 1 &nbsp;  0</td>
         </tr></tbody>
     </table>

--- a/output/reports/final-report.html
+++ b/output/reports/final-report.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Final Report — Luxe Beauty Studio</title>
+  <title>Final Report — Glow &amp; Go Beauty Bar</title>
   <style>
     *, *::before, *::after { box-sizing: border-box; }
     body { font-family: system-ui, -apple-system, sans-serif; margin: 0; color: #1a1a1a; background: #f8f8f6; line-height: 1.55; font-size: 15px; }
@@ -35,9 +35,9 @@
 
     <div class="report-header">
   <h1>Final Report</h1>
-  <p class="business">Luxe Beauty Studio</p>
+  <p class="business">Glow &amp; Go Beauty Bar</p>
   <div class="meta">
-    <span>Generated: Jun 15, 2026, 2:03 PM</span>
+    <span>Generated: Jun 20, 2026, 11:02 PM</span>
     <span>Framework: Stitchfy v2</span>
     <span>Blueprint: output/blueprint/website-blueprint.v1.json</span>
   </div>
@@ -47,19 +47,19 @@
     <div class="cards">
       <div class="card">
     <div class="card-label">Business</div>
-    <div class="card-value" style="">Luxe Beauty Studio</div>
+    <div class="card-value" style="">Glow &amp; Go Beauty Bar</div>
   </div>
       <div class="card">
     <div class="card-label">Industry</div>
-    <div class="card-value" style="">Beauty Salon</div>
+    <div class="card-value" style="">Beauty Salon / Blowout Bar</div>
   </div>
       <div class="card">
     <div class="card-label">Location</div>
-    <div class="card-value" style="">Austin, TX</div>
+    <div class="card-value" style="">Miami Beach, FL</div>
   </div>
       <div class="card">
     <div class="card-label">Pages Generated</div>
-    <div class="card-value" style="">6</div>
+    <div class="card-value" style="">4</div>
   </div>
       <div class="card">
     <div class="card-label">Static Site</div>
@@ -87,15 +87,15 @@
     <div class="cards">
       <div class="card">
     <div class="card-label">Total checks</div>
-    <div class="card-value" style="">84</div>
+    <div class="card-value" style="">28</div>
   </div>
       <div class="card">
     <div class="card-label">Passed</div>
-    <div class="card-value" style="color: #27ae60;">78</div>
+    <div class="card-value" style="color: #27ae60;">26</div>
   </div>
       <div class="card">
     <div class="card-label">Warnings</div>
-    <div class="card-value" style="color: #e67e22;">6</div>
+    <div class="card-value" style="color: #e67e22;">2</div>
   </div>
       <div class="card">
     <div class="card-label">Failures</div>
@@ -113,33 +113,21 @@
       <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
     </tr>
 <tr>
-      <td>services</td>
-      <td><code>/services</code></td>
-      <td><code>app/services/page.tsx</code></td>
+      <td>services-pricing</td>
+      <td><code>/services-pricing</code></td>
+      <td><code>app/services-pricing/page.tsx</code></td>
       <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
     </tr>
 <tr>
-      <td>gallery</td>
-      <td><code>/gallery</code></td>
-      <td><code>app/gallery/page.tsx</code></td>
-      <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-    </tr>
-<tr>
-      <td>about-us</td>
-      <td><code>/about</code></td>
-      <td><code>app/about/page.tsx</code></td>
+      <td>book-now</td>
+      <td><code>/book-now</code></td>
+      <td><code>app/book-now/page.tsx</code></td>
       <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
     </tr>
 <tr>
       <td>contact</td>
       <td><code>/contact</code></td>
       <td><code>app/contact/page.tsx</code></td>
-      <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-    </tr>
-<tr>
-      <td>book-online</td>
-      <td><code>/book</code></td>
-      <td><code>app/book/page.tsx</code></td>
       <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
     </tr></tbody>
     </table>

--- a/output/reports/seo-report.html
+++ b/output/reports/seo-report.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>SEO Report — Luxe Beauty Studio</title>
+  <title>SEO Report — Glow &amp; Go Beauty Bar</title>
   <style>
     *, *::before, *::after { box-sizing: border-box; }
     body { font-family: system-ui, -apple-system, sans-serif; margin: 0; color: #1a1a1a; background: #f8f8f6; line-height: 1.55; font-size: 15px; }
@@ -35,9 +35,9 @@
 
     <div class="report-header">
   <h1>SEO Report</h1>
-  <p class="business">Luxe Beauty Studio</p>
+  <p class="business">Glow &amp; Go Beauty Bar</p>
   <div class="meta">
-    <span>Generated: Jun 15, 2026, 2:03 PM</span>
+    <span>Generated: Jun 20, 2026, 11:02 PM</span>
     <span>Framework: Stitchfy v2</span>
     <span>Blueprint: output/blueprint/website-blueprint.v1.json</span>
   </div>
@@ -47,7 +47,7 @@
     <div class="cards">
       <div class="card">
     <div class="card-label">Pages</div>
-    <div class="card-value" style="">6</div>
+    <div class="card-value" style="">4</div>
   </div>
       <div class="card">
     <div class="card-label">Site Title</div>
@@ -72,33 +72,23 @@
       <thead><tr><th>Page</th><th>Title (30–70 chars)</th><th>Description (70–160 chars)</th></tr></thead>
       <tbody><tr>
       <td>home</td>
-      <td>Luxe Beauty Studio | Beauty Salon in Austin, TX <span class="badge" style="background:#27ae60">✓ PASS</span><br><small>47 chars</small></td>
-      <td>Welcome to Luxe Beauty Studio. Convert visitors to bookings; showcase brand and top services <span class="badge" style="background:#27ae60">✓ PASS</span><br><small>92 chars</small></td>
+      <td>Glow &amp; Go Beauty Bar | Beauty Salon / Blowout Bar in Miami Beach, FL <span class="badge" style="background:#27ae60">✓ PASS</span><br><small>68 chars</small></td>
+      <td>Welcome to Glow &amp; Go Beauty Bar. Convert visitors to bookings; showcase brand and top services <span class="badge" style="background:#27ae60">✓ PASS</span><br><small>94 chars</small></td>
     </tr>
 <tr>
-      <td>services</td>
-      <td>Services | Luxe Beauty Studio <span class="badge" style="background:#e67e22">⚠ WARN</span><br><small>29 chars</small></td>
-      <td>Explore all services offered by Luxe Beauty Studio. Detail all services with descriptions and pricing <span class="badge" style="background:#27ae60">✓ PASS</span><br><small>101 chars</small></td>
+      <td>services-pricing</td>
+      <td>Services &amp; Pricing | Glow &amp; Go Beauty Bar <span class="badge" style="background:#27ae60">✓ PASS</span><br><small>41 chars</small></td>
+      <td>Introduce the business and drive the primary contact/booking action <span class="badge" style="background:#e67e22">⚠ WARN</span><br><small>67 chars</small></td>
     </tr>
 <tr>
-      <td>gallery</td>
-      <td>Gallery | Luxe Beauty Studio <span class="badge" style="background:#e67e22">⚠ WARN</span><br><small>28 chars</small></td>
-      <td>Browse our work at Luxe Beauty Studio. See before-and-after photos and finished results. <span class="badge" style="background:#27ae60">✓ PASS</span><br><small>88 chars</small></td>
-    </tr>
-<tr>
-      <td>about-us</td>
-      <td>About Us | Luxe Beauty Studio <span class="badge" style="background:#e67e22">⚠ WARN</span><br><small>29 chars</small></td>
-      <td>Learn about the team and philosophy at Luxe Beauty Studio in Austin, TX. <span class="badge" style="background:#27ae60">✓ PASS</span><br><small>72 chars</small></td>
+      <td>book-now</td>
+      <td>Book Now | Glow &amp; Go Beauty Bar <span class="badge" style="background:#27ae60">✓ PASS</span><br><small>31 chars</small></td>
+      <td>Introduce the business and drive the primary contact/booking action <span class="badge" style="background:#e67e22">⚠ WARN</span><br><small>67 chars</small></td>
     </tr>
 <tr>
       <td>contact</td>
-      <td>Contact | Luxe Beauty Studio <span class="badge" style="background:#e67e22">⚠ WARN</span><br><small>28 chars</small></td>
-      <td>Get in touch with Luxe Beauty Studio. Find our address, phone, and hours. <span class="badge" style="background:#27ae60">✓ PASS</span><br><small>73 chars</small></td>
-    </tr>
-<tr>
-      <td>book-online</td>
-      <td>Book Online | Luxe Beauty Studio <span class="badge" style="background:#27ae60">✓ PASS</span><br><small>32 chars</small></td>
-      <td>Book your appointment online at Luxe Beauty Studio. Easy, fast scheduling. <span class="badge" style="background:#27ae60">✓ PASS</span><br><small>74 chars</small></td>
+      <td>Contact | Glow &amp; Go Beauty Bar <span class="badge" style="background:#27ae60">✓ PASS</span><br><small>30 chars</small></td>
+      <td>Get in touch with Glow &amp; Go Beauty Bar. Find our address, phone, and hours. <span class="badge" style="background:#27ae60">✓ PASS</span><br><small>75 chars</small></td>
     </tr></tbody>
     </table>
 
@@ -139,111 +129,6 @@
         <td style="opacity:0.7; font-size:0.85rem"></td>
       </tr>
 <tr>
-        <td>Services</td>
-        <td><code>page-title</code></td>
-        <td>Page has a descriptive title</td>
-        <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-        <td style="opacity:0.7; font-size:0.85rem">&quot;Services | Luxe Beauty Studio | Luxe Beauty Studio&quot;</td>
-      </tr>
-<tr>
-        <td>Services</td>
-        <td><code>meta-description</code></td>
-        <td>Meta description present</td>
-        <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-        <td style="opacity:0.7; font-size:0.85rem">Check that content is non-empty and ≤ 160 characters</td>
-      </tr>
-<tr>
-        <td>Services</td>
-        <td><code>one-h1</code></td>
-        <td>Page has exactly one H1</td>
-        <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-        <td style="opacity:0.7; font-size:0.85rem">Found 1 H1 element</td>
-      </tr>
-<tr>
-        <td>Services</td>
-        <td><code>image-alt-text</code></td>
-        <td>All &lt;img&gt; elements have alt attributes</td>
-        <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-        <td style="opacity:0.7; font-size:0.85rem"></td>
-      </tr>
-<tr>
-        <td>Services</td>
-        <td><code>canonical</code></td>
-        <td>Canonical link tag present</td>
-        <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-        <td style="opacity:0.7; font-size:0.85rem"></td>
-      </tr>
-<tr>
-        <td>Gallery</td>
-        <td><code>page-title</code></td>
-        <td>Page has a descriptive title</td>
-        <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-        <td style="opacity:0.7; font-size:0.85rem">&quot;Gallery | Luxe Beauty Studio | Luxe Beauty Studio&quot;</td>
-      </tr>
-<tr>
-        <td>Gallery</td>
-        <td><code>meta-description</code></td>
-        <td>Meta description present</td>
-        <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-        <td style="opacity:0.7; font-size:0.85rem">Check that content is non-empty and ≤ 160 characters</td>
-      </tr>
-<tr>
-        <td>Gallery</td>
-        <td><code>one-h1</code></td>
-        <td>Page has exactly one H1</td>
-        <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-        <td style="opacity:0.7; font-size:0.85rem">Found 1 H1 element</td>
-      </tr>
-<tr>
-        <td>Gallery</td>
-        <td><code>image-alt-text</code></td>
-        <td>All &lt;img&gt; elements have alt attributes</td>
-        <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-        <td style="opacity:0.7; font-size:0.85rem"></td>
-      </tr>
-<tr>
-        <td>Gallery</td>
-        <td><code>canonical</code></td>
-        <td>Canonical link tag present</td>
-        <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-        <td style="opacity:0.7; font-size:0.85rem"></td>
-      </tr>
-<tr>
-        <td>About Us</td>
-        <td><code>page-title</code></td>
-        <td>Page has a descriptive title</td>
-        <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-        <td style="opacity:0.7; font-size:0.85rem">&quot;About Us | Luxe Beauty Studio | Luxe Beauty Studio&quot;</td>
-      </tr>
-<tr>
-        <td>About Us</td>
-        <td><code>meta-description</code></td>
-        <td>Meta description present</td>
-        <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-        <td style="opacity:0.7; font-size:0.85rem">Check that content is non-empty and ≤ 160 characters</td>
-      </tr>
-<tr>
-        <td>About Us</td>
-        <td><code>one-h1</code></td>
-        <td>Page has exactly one H1</td>
-        <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-        <td style="opacity:0.7; font-size:0.85rem">Found 1 H1 element</td>
-      </tr>
-<tr>
-        <td>About Us</td>
-        <td><code>image-alt-text</code></td>
-        <td>All &lt;img&gt; elements have alt attributes</td>
-        <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-        <td style="opacity:0.7; font-size:0.85rem"></td>
-      </tr>
-<tr>
-        <td>About Us</td>
-        <td><code>canonical</code></td>
-        <td>Canonical link tag present</td>
-        <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-        <td style="opacity:0.7; font-size:0.85rem"></td>
-      </tr>
-<tr>
         <td>Contact</td>
         <td><code>page-title</code></td>
         <td>Page has a descriptive title</td>
@@ -277,41 +162,6 @@
         <td>Canonical link tag present</td>
         <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
         <td style="opacity:0.7; font-size:0.85rem"></td>
-      </tr>
-<tr>
-        <td>Book Online</td>
-        <td><code>page-title</code></td>
-        <td>Page has a descriptive title</td>
-        <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-        <td style="opacity:0.7; font-size:0.85rem">&quot;Book Online | Luxe Beauty Studio | Luxe Beauty Studio&quot;</td>
-      </tr>
-<tr>
-        <td>Book Online</td>
-        <td><code>meta-description</code></td>
-        <td>Meta description present</td>
-        <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-        <td style="opacity:0.7; font-size:0.85rem">Check that content is non-empty and ≤ 160 characters</td>
-      </tr>
-<tr>
-        <td>Book Online</td>
-        <td><code>one-h1</code></td>
-        <td>Page has exactly one H1</td>
-        <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-        <td style="opacity:0.7; font-size:0.85rem">Found 1 H1 element</td>
-      </tr>
-<tr>
-        <td>Book Online</td>
-        <td><code>image-alt-text</code></td>
-        <td>All &lt;img&gt; elements have alt attributes</td>
-        <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-        <td style="opacity:0.7; font-size:0.85rem"></td>
-      </tr>
-<tr>
-        <td>Book Online</td>
-        <td><code>canonical</code></td>
-        <td>Canonical link tag present</td>
-        <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
-        <td style="opacity:0.7; font-size:0.85rem"></td>
       </tr></tbody></table>
 
     <h2>Structured Data Recommendations</h2>
@@ -320,14 +170,14 @@
 <li>Include: url, image, sameAs (social profile URLs)</li>
 <li>Add @type: WebSite with SearchAction for sitelinks search box potential</li>
 <li>Add @type: BreadcrumbList on inner pages</li>
-<li>Add @type: Service for each of: Haircuts &amp; Styling, Color &amp; Balayage, Blowouts &amp; Deep Treatments</li></ul>
+<li>Add @type: Service for each of: Express Blowouts (45 min), Signature Blowout (60 min), Updos &amp; Event Styling</li></ul>
 
     <h2>Local SEO Checklist</h2>
-    <ul><li>Claim and optimize Google Business Profile for &quot;Luxe Beauty Studio&quot;</li>
-<li>NAP consistency: &quot;Luxe Beauty Studio&quot; / &quot;1234 South Congress Avenue, Suite 102, Austin, TX 78704&quot; / &quot;(512) 555-0190&quot; must be identical everywhere</li>
-<li>Create local citations on Yelp, YellowPages, and Beauty Salon-specific directories</li>
+    <ul><li>Claim and optimize Google Business Profile for &quot;Glow &amp; Go Beauty Bar&quot;</li>
+<li>NAP consistency: &quot;Glow &amp; Go Beauty Bar&quot; / &quot;800 Collins Avenue, Miami Beach, FL 33139&quot; / &quot;(305) 555-0210&quot; must be identical everywhere</li>
+<li>Create local citations on Yelp, YellowPages, and Beauty Salon / Blowout Bar-specific directories</li>
 <li>Use schema.org LocalBusiness (or sub-type) JSON-LD on every page</li>
-<li>Target geo-modified keywords: &quot;Beauty Salon in Austin, TX&quot;, &quot;best beauty salon near me&quot;</li>
+<li>Target geo-modified keywords: &quot;Beauty Salon / Blowout Bar in Miami Beach, FL&quot;, &quot;best beauty salon / blowout bar near me&quot;</li>
 <li>Embed Google Maps on Contact page (static iframe, no API key needed)</li>
 <li>Encourage Google reviews — display schema-compliant review markup</li></ul>
 
@@ -346,15 +196,15 @@
       <thead><tr><th>Property</th><th>Value</th></tr></thead>
       <tbody>
         <tr><td><code>og:type</code></td><td>website</td></tr>
-<tr><td><code>og:site_name</code></td><td>Luxe Beauty Studio</td></tr>
-<tr><td><code>og:title</code></td><td>Luxe Beauty Studio | Beauty Salon in Austin, TX</td></tr>
-<tr><td><code>og:description</code></td><td>Beauty Salon in Austin, TX. Luxe Beauty Studio offers Haircuts &amp; Styling, Color &amp; Balayage, Blowouts &amp; Deep Treatments and more. Book online today.</td></tr>
+<tr><td><code>og:site_name</code></td><td>Glow &amp; Go Beauty Bar</td></tr>
+<tr><td><code>og:title</code></td><td>Glow &amp; Go Beauty Bar | Beauty Salon / Blowout Bar in Miami Beach, FL</td></tr>
+<tr><td><code>og:description</code></td><td>Beauty Salon / Blowout Bar in Miami Beach, FL. Glow &amp; Go Beauty Bar offers Express Blowouts (45 min), Signature Blowout (60 min), Updos &amp; Event Styling and more</td></tr>
 <tr><td><code>og:image</code></td><td>/og-image.jpg</td></tr>
 <tr><td><code>og:image:width</code></td><td>1200</td></tr>
 <tr><td><code>og:image:height</code></td><td>630</td></tr>
 <tr><td><code>twitter:card</code></td><td>summary_large_image</td></tr>
-<tr><td><code>twitter:title</code></td><td>Luxe Beauty Studio | Beauty Salon in Austin, TX</td></tr>
-<tr><td><code>twitter:description</code></td><td>Beauty Salon in Austin, TX. Luxe Beauty Studio offers Haircuts &amp; Styling, Color &amp; Balayage, Blowouts &amp; Deep Treatments and more. Book online today.</td></tr>
+<tr><td><code>twitter:title</code></td><td>Glow &amp; Go Beauty Bar | Beauty Salon / Blowout Bar in Miami Beach, FL</td></tr>
+<tr><td><code>twitter:description</code></td><td>Beauty Salon / Blowout Bar in Miami Beach, FL. Glow &amp; Go Beauty Bar offers Express Blowouts (45 min), Signature Blowout (60 min), Updos &amp; Event Styling and more</td></tr>
       </tbody>
     </table>
 

--- a/output/reports/stitch-review-report.html
+++ b/output/reports/stitch-review-report.html
@@ -1,0 +1,199 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Stitch Review Report</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: #f8f9fa; color: #1a1a2e; line-height: 1.6; }
+  .header { background: linear-gradient(135deg, #b30069 0%, #7a004a 100%); color: #fff; padding: 2rem 2.5rem; }
+  .header h1 { font-size: 1.6rem; font-weight: 700; }
+  .header p  { font-size: 0.875rem; opacity: .8; margin-top: .25rem; }
+  .summary { display: flex; gap: 1rem; padding: 1.5rem 2.5rem; background: #fff; border-bottom: 1px solid #e5e7eb; flex-wrap: wrap; }
+  .stat { background: #f3f4f6; border-radius: 8px; padding: .75rem 1.25rem; min-width: 130px; text-align: center; }
+  .stat .num { font-size: 1.75rem; font-weight: 700; }
+  .stat .lbl { font-size: .75rem; color: #6b7280; text-transform: uppercase; letter-spacing: .05em; }
+  .stat.green .num { color: #059669; }
+  .stat.red   .num { color: #dc2626; }
+  .stat.amber .num { color: #d97706; }
+  .stat.blue  .num { color: #2563eb; }
+  .content { max-width: 960px; margin: 2rem auto; padding: 0 1.5rem 3rem; }
+  .page-card { background: #fff; border-radius: 10px; border: 1px solid #e5e7eb; margin-bottom: 1.5rem; overflow: hidden; }
+  .page-header { background: #f9fafb; border-bottom: 1px solid #e5e7eb; padding: .9rem 1.25rem; display: flex; align-items: center; justify-content: space-between; }
+  .page-title { font-weight: 700; font-size: 1rem; }
+  .page-route { font-size: .8rem; color: #6b7280; background: #e5e7eb; border-radius: 4px; padding: .15rem .5rem; font-family: monospace; }
+  .page-body { padding: 1.25rem; }
+  .section-label { font-size: .7rem; font-weight: 700; text-transform: uppercase; letter-spacing: .08em; color: #6b7280; margin-bottom: .6rem; margin-top: 1rem; }
+  .section-label:first-child { margin-top: 0; }
+  .patch-list, .finding-list { list-style: none; display: flex; flex-direction: column; gap: .4rem; }
+  .patch-item { display: flex; align-items: flex-start; gap: .5rem; font-size: .875rem; }
+  .patch-item::before { content: "✓"; color: #059669; font-weight: 700; flex-shrink: 0; margin-top: .05rem; }
+  .patch-skipped::before { content: "–"; color: #9ca3af; }
+  .finding-item { border-radius: 6px; padding: .6rem .9rem; font-size: .875rem; border-left: 4px solid; }
+  .finding-error   { background: #fef2f2; border-color: #dc2626; }
+  .finding-warning { background: #fffbeb; border-color: #d97706; }
+  .finding-info    { background: #eff6ff; border-color: #2563eb; }
+  .badge { display: inline-block; border-radius: 4px; padding: .15rem .45rem; font-size: .7rem; font-weight: 700; text-transform: uppercase; letter-spacing: .04em; margin-right: .4rem; }
+  .badge-error   { background: #fee2e2; color: #b91c1c; }
+  .badge-warning { background: #fef3c7; color: #92400e; }
+  .badge-info    { background: #dbeafe; color: #1e40af; }
+  .badge-seo  { background: #f3e8ff; color: #7c3aed; }
+  .badge-a11y { background: #ecfdf5; color: #065f46; }
+  .rec { margin-top: .3rem; font-size: .8rem; color: #4b5563; }
+  .empty { color: #9ca3af; font-size: .875rem; font-style: italic; }
+  .disclaimer { margin-top: 2rem; padding: 1rem 1.25rem; background: #fff; border: 1px solid #e5e7eb; border-radius: 8px; font-size: .8rem; color: #6b7280; }
+</style>
+</head>
+<body>
+<div class="header">
+  <h1>Stitchfy · Stitch Review Report</h1>
+  <p>Generated 6/20/2026, 6:11:29 PM · 4 page(s) reviewed</p>
+</div>
+<div class="summary">
+  <div class="stat green"><div class="num">25</div><div class="lbl">Auto-patched</div></div>
+  <div class="stat red">  <div class="num">5</div>  <div class="lbl">Errors</div></div>
+  <div class="stat amber"><div class="num">5</div><div class="lbl">Warnings</div></div>
+  <div class="stat blue"> <div class="num">4</div>   <div class="lbl">Info</div></div>
+</div>
+<div class="content">
+<div class="page-card">
+  <div class="page-header">
+    <span class="page-title">home</span>
+    <span class="page-route">/</span>
+  </div>
+  <div class="page-body">
+    <div class="section-label">Auto-patched (7)</div>
+    <ul class="patch-list"><li class="patch-item">JSON-LD: fix @type (BeautySalon), url, and opening hours format</li><li class="patch-item">Convert data-alt to alt on all &lt;img&gt; elements (WCAG 1.1.1)</li><li class="patch-item">Add aria-label=&quot;Main navigation&quot; to unlabelled &lt;nav&gt; (WCAG 1.3.6)</li><li class="patch-item">Add aria-label to mobile menu button (WCAG 4.1.2)</li><li class="patch-item">Add aria-hidden=&quot;true&quot; to decorative icon &quot;location_on&quot; (WCAG 1.1.1)</li><li class="patch-item">Add aria-hidden=&quot;true&quot; to decorative icon &quot;arrow_forward&quot; (WCAG 1.1.1)</li><li class="patch-item">Add aria-hidden=&quot;true&quot; to decorative icon &quot;menu&quot; (WCAG 1.1.1)</li></ul>
+    <div class="section-label">Manual review required (5)</div>
+    <div class="finding-item finding-error">
+  <span class="badge badge-error">error</span>
+  <span class="badge badge-seo">seo</span>
+  <strong>SEO: og:image missing</strong><br>
+  No og:image meta tag found. Social sharing previews will have no image.
+  <div class="rec">→ Add &lt;meta property=&quot;og:image&quot; content=&quot;https://yourdomain.com/og-image.jpg&quot;&gt; in the blueprint's openGraph config.</div>
+</div><div class="finding-item finding-error">
+  <span class="badge badge-error">error</span>
+  <span class="badge badge-seo">seo</span>
+  <strong>SEO: meta description is internal blueprint text</strong><br>
+  Meta description appears to be the page's internal purpose field: &quot;Welcome to Glow &amp;amp; Go Beauty Bar. Convert visitors to bookings; showcase bran...&quot;
+  <div class="rec">→ Replace with a consumer-facing description (50–160 chars) before deploying. Update seo.pageMeta in the blueprint.</div>
+</div><div class="finding-item finding-warning">
+  <span class="badge badge-warning">warning</span>
+  <span class="badge badge-seo">seo</span>
+  <strong>SEO: title too long</strong><br>
+  Page title is 68 chars. Google truncates at ~60 in SERPs.
+  <div class="rec">→ Shorten the title in the blueprint's seo.pageMeta for this page.</div>
+</div><div class="finding-item finding-warning">
+  <span class="badge badge-warning">warning</span>
+  <span class="badge badge-seo">seo</span>
+  <strong>SEO: canonical URL is relative</strong><br>
+  Canonical link is set to &quot;/&quot; (relative). Search engines expect an absolute URL.
+  <div class="rec">→ Set openGraph.url in the blueprint (e.g. https://glowandgobar.com) before deploying.</div>
+</div><div class="finding-item finding-info">
+  <span class="badge badge-info">info</span>
+  <span class="badge badge-accessibility">accessibility</span>
+  <strong>WCAG 1.3.1: footer navigation landmark</strong><br>
+  Footer contains links but no &lt;nav&gt; landmark. Keyboard and AT users cannot jump to footer nav.
+  <div class="rec">→ Wrap footer links in &lt;nav aria-label=&quot;Footer navigation&quot;&gt;. This is a structural change — not auto-patched.</div>
+</div>
+  </div>
+</div>
+<div class="page-card">
+  <div class="page-header">
+    <span class="page-title">services-pricing</span>
+    <span class="page-route">/services-pricing</span>
+  </div>
+  <div class="page-body">
+    <div class="section-label">Auto-patched (7)</div>
+    <ul class="patch-list"><li class="patch-item">Convert data-alt to alt on all &lt;img&gt; elements (WCAG 1.1.1)</li><li class="patch-item">Add aria-label=&quot;Main navigation&quot; to unlabelled &lt;nav&gt; (WCAG 1.3.6)</li><li class="patch-item">Add aria-label to mobile menu button (WCAG 4.1.2)</li><li class="patch-item">Add aria-hidden=&quot;true&quot; to decorative icon &quot;location_on&quot; (WCAG 1.1.1)</li><li class="patch-item">Add aria-hidden=&quot;true&quot; to decorative icon &quot;schedule&quot; (WCAG 1.1.1)</li><li class="patch-item">Add aria-hidden=&quot;true&quot; to decorative icon &quot;arrow_forward&quot; (WCAG 1.1.1)</li><li class="patch-item">Add aria-hidden=&quot;true&quot; to decorative icon &quot;menu&quot; (WCAG 1.1.1)</li></ul>
+    <div class="section-label">Manual review required (3)</div>
+    <div class="finding-item finding-error">
+  <span class="badge badge-error">error</span>
+  <span class="badge badge-seo">seo</span>
+  <strong>SEO: og:image missing</strong><br>
+  No og:image meta tag found. Social sharing previews will have no image.
+  <div class="rec">→ Add &lt;meta property=&quot;og:image&quot; content=&quot;https://yourdomain.com/og-image.jpg&quot;&gt; in the blueprint's openGraph config.</div>
+</div><div class="finding-item finding-warning">
+  <span class="badge badge-warning">warning</span>
+  <span class="badge badge-seo">seo</span>
+  <strong>SEO: canonical URL is relative</strong><br>
+  Canonical link is set to &quot;/&quot; (relative). Search engines expect an absolute URL.
+  <div class="rec">→ Set openGraph.url in the blueprint (e.g. https://glowandgobar.com) before deploying.</div>
+</div><div class="finding-item finding-info">
+  <span class="badge badge-info">info</span>
+  <span class="badge badge-accessibility">accessibility</span>
+  <strong>WCAG 1.3.1: footer navigation landmark</strong><br>
+  Footer contains links but no &lt;nav&gt; landmark. Keyboard and AT users cannot jump to footer nav.
+  <div class="rec">→ Wrap footer links in &lt;nav aria-label=&quot;Footer navigation&quot;&gt;. This is a structural change — not auto-patched.</div>
+</div>
+  </div>
+</div>
+<div class="page-card">
+  <div class="page-header">
+    <span class="page-title">book-now</span>
+    <span class="page-route">/book-now</span>
+  </div>
+  <div class="page-body">
+    <div class="section-label">Auto-patched (7)</div>
+    <ul class="patch-list"><li class="patch-item">Add aria-label=&quot;Main navigation&quot; to unlabelled &lt;nav&gt; (WCAG 1.3.6)</li><li class="patch-item">Add aria-label to mobile menu button (WCAG 4.1.2)</li><li class="patch-item">Add aria-hidden=&quot;true&quot; to decorative icon &quot;location_on&quot; (WCAG 1.1.1)</li><li class="patch-item">Add aria-hidden=&quot;true&quot; to decorative icon &quot;schedule&quot; (WCAG 1.1.1)</li><li class="patch-item">Add aria-hidden=&quot;true&quot; to decorative icon &quot;arrow_forward&quot; (WCAG 1.1.1)</li><li class="patch-item">Add aria-hidden=&quot;true&quot; to decorative icon &quot;phone&quot; (WCAG 1.1.1)</li><li class="patch-item">Add aria-hidden=&quot;true&quot; to decorative icon &quot;menu&quot; (WCAG 1.1.1)</li></ul>
+    <div class="section-label">Manual review required (4)</div>
+    <div class="finding-item finding-error">
+  <span class="badge badge-error">error</span>
+  <span class="badge badge-seo">seo</span>
+  <strong>SEO: og:image missing</strong><br>
+  No og:image meta tag found. Social sharing previews will have no image.
+  <div class="rec">→ Add &lt;meta property=&quot;og:image&quot; content=&quot;https://yourdomain.com/og-image.jpg&quot;&gt; in the blueprint's openGraph config.</div>
+</div><div class="finding-item finding-warning">
+  <span class="badge badge-warning">warning</span>
+  <span class="badge badge-seo">seo</span>
+  <strong>SEO: canonical URL is relative</strong><br>
+  Canonical link is set to &quot;/&quot; (relative). Search engines expect an absolute URL.
+  <div class="rec">→ Set openGraph.url in the blueprint (e.g. https://glowandgobar.com) before deploying.</div>
+</div><div class="finding-item finding-warning">
+  <span class="badge badge-warning">warning</span>
+  <span class="badge badge-accessibility">accessibility</span>
+  <strong>WCAG 2.4.7: focus visible</strong><br>
+  Found 3 uses of focus:outline-none. One (the menu button) is auto-patched. Others may suppress focus indicators.
+  <div class="rec">→ Search for focus:outline-none in the page and replace with focus:ring-* utilities.</div>
+</div><div class="finding-item finding-info">
+  <span class="badge badge-info">info</span>
+  <span class="badge badge-accessibility">accessibility</span>
+  <strong>WCAG 1.3.1: footer navigation landmark</strong><br>
+  Footer contains links but no &lt;nav&gt; landmark. Keyboard and AT users cannot jump to footer nav.
+  <div class="rec">→ Wrap footer links in &lt;nav aria-label=&quot;Footer navigation&quot;&gt;. This is a structural change — not auto-patched.</div>
+</div>
+  </div>
+</div>
+<div class="page-card">
+  <div class="page-header">
+    <span class="page-title">contact</span>
+    <span class="page-route">/contact</span>
+  </div>
+  <div class="page-body">
+    <div class="section-label">Auto-patched (4)</div>
+    <ul class="patch-list"><li class="patch-item">Add aria-label=&quot;Main navigation&quot; to unlabelled &lt;nav&gt; (WCAG 1.3.6)</li><li class="patch-item">Add aria-label to mobile menu button (WCAG 4.1.2)</li><li class="patch-item">Add aria-hidden=&quot;true&quot; to decorative icon &quot;location_on&quot; (WCAG 1.1.1)</li><li class="patch-item">Add aria-hidden=&quot;true&quot; to decorative icon &quot;menu&quot; (WCAG 1.1.1)</li></ul>
+    <div class="section-label">Manual review required (2)</div>
+    <div class="finding-item finding-error">
+  <span class="badge badge-error">error</span>
+  <span class="badge badge-seo">seo</span>
+  <strong>SEO: og:image missing</strong><br>
+  No og:image meta tag found. Social sharing previews will have no image.
+  <div class="rec">→ Add &lt;meta property=&quot;og:image&quot; content=&quot;https://yourdomain.com/og-image.jpg&quot;&gt; in the blueprint's openGraph config.</div>
+</div><div class="finding-item finding-info">
+  <span class="badge badge-info">info</span>
+  <span class="badge badge-accessibility">accessibility</span>
+  <strong>WCAG 1.3.1: footer navigation landmark</strong><br>
+  Footer contains links but no &lt;nav&gt; landmark. Keyboard and AT users cannot jump to footer nav.
+  <div class="rec">→ Wrap footer links in &lt;nav aria-label=&quot;Footer navigation&quot;&gt;. This is a structural change — not auto-patched.</div>
+</div>
+  </div>
+</div>
+<div class="disclaimer">
+  <strong>Note:</strong> Auto-patches are attribute-level only (aria-label, alt, aria-hidden, JSON-LD rewrite).
+  No structural changes were made. Findings marked <em>error</em> or <em>warning</em> require human review
+  before deploying to production. This report does not constitute a full WCAG or legal compliance audit.
+</div>
+</div>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stitchfy",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "AI-powered Markdown-to-static-website framework for small and mid-sized businesses",
   "license": "Apache-2.0",
   "author": "Devify LLC",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "validate": "tsx scripts/validate.ts",
     "build:site": "tsx scripts/build-site.ts",
     "audit": "tsx scripts/audit-site.ts",
+    "build:site:stitch": "tsx scripts/build-site-stitch.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -12,8 +12,10 @@
     "stitchfy": "tsx scripts/run-stitchfy.ts",
     "validate": "tsx scripts/validate.ts",
     "build:site": "tsx scripts/build-site.ts",
-    "audit": "tsx scripts/audit-site.ts",
     "build:site:stitch": "tsx scripts/build-site-stitch.ts",
+    "audit": "tsx scripts/audit-site.ts",
+    "audit:stitch": "tsx scripts/audit-site.ts --dir stitch",
+    "audit:both": "tsx scripts/audit-site.ts --dir both",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/scripts/audit-site.ts
+++ b/scripts/audit-site.ts
@@ -1,53 +1,142 @@
 #!/usr/bin/env tsx
 /**
  * audit-site — Generates HTML audit reports from the blueprint and
- * optionally analyzes the generated static HTML for accessibility and SEO issues.
+ * analyzes the generated static HTML for accessibility and SEO issues.
  *
- * Steps:
- *   1. Read the blueprint
- *   2. Locate HTML files in output/static-site/ (if built)
- *   3. Run static HTML checks on each page
- *   4. Generate HTML reports → output/reports/
+ * Supports both output strategies:
+ *   --dir static   Audit output/static-site/ (default, v2.0.0 behavior)
+ *   --dir stitch   Audit output/stitch-site/ → prefixed stitch-*.html reports
+ *   --dir both     Run both audits in sequence
  *
  * Usage:
- *   npm run audit
- *   npm run audit -- --blueprint path/to/blueprint.json
+ *   npm run audit                          ← static-site (default)
+ *   npm run audit -- --dir stitch          ← stitch-site
+ *   npm run audit -- --dir both            ← both
+ *   npm run audit -- --blueprint path.json ← custom blueprint
  */
 
 import * as fs from "fs";
 import * as path from "path";
-import { generateReports, analyzeHtmlFile, type PageAnalysis, type ReportData } from "../framework/core/report-generator.js";
+import {
+  generateReports,
+  analyzeHtmlFile,
+  type PageAnalysis,
+  type ReportData,
+} from "../framework/core/report-generator.js";
 import type { WebsiteBlueprint } from "../framework/schemas/blueprint.types.js";
 
+// ─── Arg parsing ──────────────────────────────────────────────────────────────
+
 const args = process.argv.slice(2);
-const getBlueprintPath = () => {
-  const i = args.indexOf("--blueprint");
-  return i !== -1 && args[i + 1]
-    ? path.resolve(args[i + 1])
-    : path.resolve("output/blueprint/website-blueprint.v1.json");
-};
+
+function getArg(flag: string): string | undefined {
+  const i = args.indexOf(flag);
+  return i !== -1 && args[i + 1] ? args[i + 1] : undefined;
+}
+
+const dirArg  = (getArg("--dir") ?? "static") as "static" | "stitch" | "both";
+const blueprintPath = path.resolve(
+  getArg("--blueprint") ?? "output/blueprint/website-blueprint.v1.json"
+);
+
+const DIVIDER = "━".repeat(52);
 
 function step(n: number, total: number, label: string) {
   console.log(`\n  [${n}/${total}] ${label}...`);
 }
-function ok(msg: string) { console.log(`  ✓  ${msg}`); }
+function ok(msg: string)   { console.log(`  ✓  ${msg}`); }
 function warn(msg: string) { console.log(`  ⚠  ${msg}`); }
+function fail(msg: string) { console.error(`  ✗  ${msg}`); }
+
+// ─── Core audit runner (reusable by build-site-stitch.ts) ────────────────────
+
+export interface AuditResult {
+  siteDir: string;
+  reportsWritten: string[];
+  passCount: number;
+  warnCount: number;
+  failCount: number;
+}
+
+export async function runAudit(
+  blueprint: WebsiteBlueprint,
+  siteDir: string,
+  outputDir: string,
+  reportPrefix: string,
+  onProgress?: (msg: string) => void
+): Promise<AuditResult> {
+  const log = onProgress ?? (() => {});
+  const siteExists = fs.existsSync(siteDir) && countFiles(siteDir) > 0;
+  const reportsWritten: string[] = [];
+
+  if (!siteExists) {
+    log(`⚠  ${siteDir} is empty or missing — HTML checks will be skipped`);
+  }
+
+  // Analyse each page from the blueprint
+  const pageAnalyses: PageAnalysis[] = [];
+
+  for (const route of blueprint.frontend.routes) {
+    const page = blueprint.pages.find((p) => p.id === route.pageId);
+    const title = page?.title ?? route.pageId;
+    const htmlFile = locateHtmlFile(siteDir, route.path);
+    let checks: ReturnType<typeof analyzeHtmlFile> = [];
+
+    if (siteExists && fs.existsSync(htmlFile)) {
+      const html = fs.readFileSync(htmlFile, "utf-8");
+      checks = analyzeHtmlFile(html);
+      const passed = checks.filter((c) => c.status === "pass").length;
+      log(`  ${title} — ${passed}/${checks.length} checks passed`);
+    } else if (siteExists) {
+      log(`  ⚠  HTML not found for ${route.path}`);
+    }
+
+    pageAnalyses.push({ pageId: route.pageId, title, path: route.path, file: route.file, checks });
+  }
+
+  // Generate reports
+  const reportData: ReportData = {
+    blueprint,
+    blueprintPath,
+    generatedAt: new Date().toISOString(),
+    pageAnalyses,
+    staticSiteExists: siteExists,
+  };
+
+  generateReports(reportData, outputDir, reportPrefix);
+
+  reportsWritten.push(
+    `${reportPrefix}accessibility-report.html`,
+    `${reportPrefix}seo-report.html`,
+    `${reportPrefix}final-report.html`,
+  );
+
+  const allChecks = pageAnalyses.flatMap((p) => p.checks);
+  return {
+    siteDir,
+    reportsWritten,
+    passCount: allChecks.filter((c) => c.status === "pass").length,
+    warnCount: allChecks.filter((c) => c.status === "warn").length,
+    failCount: allChecks.filter((c) => c.status === "fail").length,
+  };
+}
+
+// ─── Entry point ──────────────────────────────────────────────────────────────
 
 async function main() {
-  console.log("\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+  console.log(`\n${DIVIDER}`);
   console.log("  Stitchfy v2 — Audit");
-  console.log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+  console.log(DIVIDER);
 
-  const blueprintPath = getBlueprintPath();
-  const staticDir = path.resolve("output/static-site");
   const outputDir = path.resolve("output");
-  const TOTAL = 4;
+  const TOTAL = 3;
 
-  // ── Step 1: Read blueprint ────────────────────────────────────────────────
+  // ── Step 1: Read blueprint ──────────────────────────────────────────────────
   step(1, TOTAL, "Reading blueprint");
+
   if (!fs.existsSync(blueprintPath)) {
-    console.error(`  ✗  Blueprint not found: ${blueprintPath}`);
-    console.log("  Run \"npm run stitchfy\" first.\n");
+    fail(`Blueprint not found: ${blueprintPath}`);
+    console.log('  Run "npm run stitchfy" first.\n');
     process.exit(1);
   }
 
@@ -55,99 +144,79 @@ async function main() {
   try {
     blueprint = JSON.parse(fs.readFileSync(blueprintPath, "utf-8")) as WebsiteBlueprint;
   } catch (e) {
-    console.error(`  ✗  Failed to parse blueprint: ${(e as Error).message}`);
+    fail(`Failed to parse blueprint: ${(e as Error).message}`);
     process.exit(1);
   }
   ok(`Blueprint loaded — ${blueprint.business.name}, ${blueprint.pages.length} pages`);
 
-  // ── Step 2: Check for static site ────────────────────────────────────────
-  step(2, TOTAL, "Locating static HTML files");
-  const staticSiteExists = fs.existsSync(staticDir) && countFiles(staticDir) > 0;
+  // ── Step 2: Resolve target(s) ───────────────────────────────────────────────
+  const targets: Array<{ siteDir: string; prefix: string; label: string }> = [];
 
-  if (!staticSiteExists) {
-    warn("output/static-site/ is empty or missing — HTML checks will be skipped");
-    warn("Run \"npm run build:site\" to build the site before auditing");
-  } else {
-    ok(`Found static site at output/static-site/`);
+  if (dirArg === "static" || dirArg === "both") {
+    targets.push({
+      siteDir: path.resolve("output/static-site"),
+      prefix: "",
+      label: "static-site",
+    });
   }
-
-  // ── Step 3: Analyze HTML files ─────────────────────────────────────────────
-  step(3, TOTAL, "Analyzing pages");
-  const pageAnalyses: PageAnalysis[] = [];
-
-  for (const route of blueprint.frontend.routes) {
-    const page = blueprint.pages.find((p) => p.id === route.pageId);
-    const meta = blueprint.seo.pageMeta.find((m) => m.pageId === route.pageId);
-    const title = page?.title ?? route.pageId;
-
-    // Locate the HTML file for this route
-    const htmlFile = locateHtmlFile(staticDir, route.path);
-    let checks = [];
-
-    if (staticSiteExists && htmlFile && fs.existsSync(htmlFile)) {
-      const html = fs.readFileSync(htmlFile, "utf-8");
-      checks = analyzeHtmlFile(html);
-      const passCount = checks.filter((c) => c.status === "pass").length;
-      ok(`${title} — ${passCount}/${checks.length} checks passed`);
-    } else {
-      if (staticSiteExists) {
-        warn(`HTML not found for ${route.path} — skipping analysis`);
-      }
-    }
-
-    pageAnalyses.push({
-      pageId: route.pageId,
-      title,
-      path: route.path,
-      file: route.file,
-      checks,
+  if (dirArg === "stitch" || dirArg === "both") {
+    targets.push({
+      siteDir: path.resolve("output/stitch-site"),
+      prefix: "stitch-",
+      label: "stitch-site",
     });
   }
 
-  // ── Step 4: Generate reports ──────────────────────────────────────────────
-  step(4, TOTAL, "Generating HTML reports");
-  const reportData: ReportData = {
-    blueprint,
-    blueprintPath,
-    generatedAt: new Date().toISOString(),
-    pageAnalyses,
-    staticSiteExists,
-  };
-
-  try {
-    generateReports(reportData, outputDir);
-    ok("accessibility-report.html");
-    ok("seo-report.html");
-    ok("final-report.html");
-  } catch (e) {
-    console.error(`  ✗  Report generation failed: ${(e as Error).message}`);
+  if (targets.length === 0) {
+    fail(`Unknown --dir value "${dirArg}". Use: static | stitch | both`);
     process.exit(1);
   }
 
-  // ── Summary ───────────────────────────────────────────────────────────────
-  const allChecks = pageAnalyses.flatMap((p) => p.checks);
-  const passCount = allChecks.filter((c) => c.status === "pass").length;
-  const warnCount = allChecks.filter((c) => c.status === "warn").length;
-  const failCount = allChecks.filter((c) => c.status === "fail").length;
+  // ── Step 3: Audit each target ───────────────────────────────────────────────
+  let totalFails = 0;
+  const allReports: string[] = [];
 
-  console.log("\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
-  if (staticSiteExists && allChecks.length > 0) {
-    console.log(`  HTML checks: ${passCount} passed, ${warnCount} warnings, ${failCount} failures`);
+  for (const target of targets) {
+    step(2, TOTAL, `Auditing ${target.label}`);
+
+    const result = await runAudit(
+      blueprint,
+      target.siteDir,
+      outputDir,
+      target.prefix,
+      (msg) => console.log(`  ${msg}`)
+    );
+
+    for (const r of result.reportsWritten) {
+      ok(r);
+      allReports.push(r);
+    }
+
+    if (result.passCount + result.warnCount + result.failCount > 0) {
+      ok(
+        `HTML checks: ${result.passCount} passed, ${result.warnCount} warnings, ${result.failCount} failures`
+      );
+    }
+    totalFails += result.failCount;
   }
+
+  // ── Summary ─────────────────────────────────────────────────────────────────
+  step(3, TOTAL, "Done");
+  console.log(`\n${DIVIDER}`);
   console.log("  Reports written to output/reports/");
-  console.log("    → accessibility-report.html");
-  console.log("    → seo-report.html");
-  console.log("    → final-report.html");
-  if (failCount > 0) {
-    console.log(`\n  ⚠  ${failCount} check(s) failed — review accessibility-report.html`);
+  for (const r of allReports) console.log(`    → ${r}`);
+  if (totalFails > 0) {
+    console.log(`\n  ⚠  ${totalFails} check(s) failed — review the accessibility report(s)`);
   }
-  console.log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
+  console.log(`${DIVIDER}\n`);
 }
 
-function locateHtmlFile(staticDir: string, routePath: string): string {
-  if (routePath === "/") return path.join(staticDir, "index.html");
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function locateHtmlFile(siteDir: string, routePath: string): string {
+  if (routePath === "/") return path.join(siteDir, "index.html");
   const slug = routePath.replace(/^\//, "").replace(/\/$/, "");
-  return path.join(staticDir, slug, "index.html");
+  return path.join(siteDir, slug, "index.html");
 }
 
 function countFiles(dir: string): number {

--- a/scripts/build-site-stitch.ts
+++ b/scripts/build-site-stitch.ts
@@ -2,17 +2,12 @@
 /**
  * build-site-stitch — Generates a static website via Google Stitch MCP.
  *
- * Unlike build-site (which uses template-based code generation), this script
- * sends each page through the Stitch AI design pipeline and assembles the
- * resulting HTML into a deployable site.
- *
  * Steps:
- *   1. Read output/blueprint/website-blueprint.v1.json (or --blueprint path)
- *   2. Create a Stitch project for this business
- *   3. Generate one AI screen per blueprint page (uses STITCH_MODEL, default: GEMINI_3_PRO)
- *   4. Call build_site — maps all screens to routes, returns full HTML per page
- *   5. Post-process — inject SEO meta tags, JSON-LD, skip link, lang attribute
- *   6. Write output/stitch-site/{route}/index.html for every page
+ *   1. Read blueprint
+ *   2. Generate pages via Stitch (create project → screens → get HTML →
+ *      post-process → SEO/A11y agent review → patch → write)
+ *   3. Run general HTML audit on output/stitch-site/ → stitch-*.html reports
+ *   4. Done
  *
  * Requirements:
  *   STITCH_API_KEY must be set in .env or the environment.
@@ -20,24 +15,27 @@
  * Usage:
  *   npm run build:site:stitch
  *   npm run build:site:stitch -- --blueprint path/to/blueprint.json
+ *   npm run build:site:stitch -- --no-audit   (skip step 3)
  *   STITCH_MODEL=GEMINI_3_FLASH npm run build:site:stitch
  */
 
 import * as fs from "fs";
 import * as path from "path";
 import { generateWithStitch } from "../framework/core/stitch-generator.js";
+import { runAudit } from "./audit-site.js";
 import type { WebsiteBlueprint } from "../framework/schemas/blueprint.types.js";
 
-// Load .env if present (Node 18 does not auto-load .env)
 loadDotEnv(path.resolve(".env"));
 
 const args = process.argv.slice(2);
-const getBlueprintPath = (): string => {
-  const i = args.indexOf("--blueprint");
-  return i !== -1 && args[i + 1]
-    ? path.resolve(args[i + 1])
-    : path.resolve("output/blueprint/website-blueprint.v1.json");
-};
+
+function getArg(flag: string): string | undefined {
+  const i = args.indexOf(flag);
+  return i !== -1 && args[i + 1] ? args[i + 1] : undefined;
+}
+
+const blueprintPath = path.resolve(getArg("--blueprint") ?? "output/blueprint/website-blueprint.v1.json");
+const skipAudit     = args.includes("--no-audit");
 
 const DIVIDER = "━".repeat(52);
 
@@ -49,13 +47,13 @@ function warn(msg: string) { console.warn(`  ⚠  ${msg}`); }
 function fail(msg: string) { console.error(`  ✗  ${msg}`); }
 
 async function main() {
+  const TOTAL = skipAudit ? 3 : 4;
+
   console.log(`\n${DIVIDER}`);
   console.log("  Stitchfy v2 — Build with Google Stitch");
   console.log(DIVIDER);
 
-  const blueprintPath = getBlueprintPath();
-  const outputDir     = path.resolve("output/stitch-site");
-  const TOTAL         = 3;
+  const outputDir = path.resolve("output/stitch-site");
 
   // ── Step 1: Read blueprint ──────────────────────────────────────────────────
   step(1, TOTAL, "Reading blueprint");
@@ -74,12 +72,9 @@ async function main() {
     process.exit(1);
   }
 
-  ok(
-    `Blueprint loaded — ${blueprint.pages.length} pages` +
-    ` | ${blueprint.business.name} | ${blueprint.business.industry}`
-  );
+  ok(`Blueprint loaded — ${blueprint.pages.length} pages | ${blueprint.business.name} | ${blueprint.business.industry}`);
   console.log(`  Output: ${outputDir}`);
-  console.log(`  Model:  ${process.env.STITCH_MODEL ?? "GEMINI_3_PRO"}`);
+  console.log(`  Model:  ${process.env.STITCH_MODEL ?? "GEMINI_3_1_PRO"}`);
 
   if (!process.env.STITCH_API_KEY) {
     fail("STITCH_API_KEY is not set.");
@@ -91,11 +86,7 @@ async function main() {
   step(2, TOTAL, `Generating ${blueprint.pages.length} page(s) via Stitch MCP`);
   console.log("  (Each page goes through Gemini — this may take 30–90 seconds per page)\n");
 
-  const result = await generateWithStitch(
-    blueprint,
-    outputDir,
-    (msg) => console.log(`  ${msg}`)
-  );
+  const result = await generateWithStitch(blueprint, outputDir, (msg) => console.log(`  ${msg}`));
 
   for (const e of result.errors)   fail(e);
   for (const w of result.warnings) warn(w);
@@ -107,20 +98,47 @@ async function main() {
 
   ok(`${result.pagesGenerated} page(s) written to output/stitch-site/`);
   ok(`Stitch project ID: ${result.projectId}`);
-  if (result.reportPath) ok(`Review report: ${result.reportPath}`);
+  if (result.reportPath) ok(`Inline review report: ${path.relative(process.cwd(), result.reportPath)}`);
 
-  // ── Step 3: Done ────────────────────────────────────────────────────────────
-  step(3, TOTAL, "Done");
+  // ── Step 3: General HTML audit ──────────────────────────────────────────────
+  if (!skipAudit) {
+    step(3, TOTAL, "Running general HTML audit on output/stitch-site/");
+
+    const auditResult = await runAudit(
+      blueprint,
+      outputDir,
+      path.resolve("output"),
+      "stitch-",
+      (msg) => console.log(`  ${msg}`)
+    );
+
+    for (const r of auditResult.reportsWritten) ok(r);
+
+    if (auditResult.passCount + auditResult.warnCount + auditResult.failCount > 0) {
+      ok(`HTML checks: ${auditResult.passCount} passed, ${auditResult.warnCount} warnings, ${auditResult.failCount} failures`);
+    }
+    if (auditResult.failCount > 0) {
+      warn(`${auditResult.failCount} check(s) failed — review output/reports/stitch-accessibility-report.html`);
+    }
+  }
+
+  // ── Step 4: Done ────────────────────────────────────────────────────────────
+  step(TOTAL, TOTAL, "Done");
 
   console.log(`\n${DIVIDER}`);
   console.log("  Stitch site ready at output/stitch-site/");
   console.log("  Open output/stitch-site/index.html to preview locally.");
-  console.log('  Run "npm run audit" to check accessibility and SEO.');
+  console.log("  Reports → output/reports/");
+  console.log("    → stitch-review-report.html      (inline agent review)");
+  if (!skipAudit) {
+    console.log("    → stitch-accessibility-report.html (general HTML audit)");
+    console.log("    → stitch-seo-report.html            (general SEO audit)");
+    console.log("    → stitch-final-report.html          (pipeline summary)");
+  }
   console.log(`${DIVIDER}\n`);
 }
 
 // ─── Minimal .env loader ──────────────────────────────────────────────────────
-// Keeps the script self-contained without requiring dotenv as a dependency.
 
 function loadDotEnv(envPath: string) {
   if (!fs.existsSync(envPath)) return;
@@ -132,9 +150,7 @@ function loadDotEnv(envPath: string) {
     if (eq === -1) continue;
     const key = line.slice(0, eq).trim();
     const val = line.slice(eq + 1).trim().replace(/^["']|["']$/g, "");
-    if (key && !(key in process.env)) {
-      process.env[key] = val;
-    }
+    if (key && !(key in process.env)) process.env[key] = val;
   }
 }
 

--- a/scripts/build-site-stitch.ts
+++ b/scripts/build-site-stitch.ts
@@ -107,6 +107,7 @@ async function main() {
 
   ok(`${result.pagesGenerated} page(s) written to output/stitch-site/`);
   ok(`Stitch project ID: ${result.projectId}`);
+  if (result.reportPath) ok(`Review report: ${result.reportPath}`);
 
   // ── Step 3: Done ────────────────────────────────────────────────────────────
   step(3, TOTAL, "Done");

--- a/scripts/build-site-stitch.ts
+++ b/scripts/build-site-stitch.ts
@@ -1,0 +1,143 @@
+#!/usr/bin/env tsx
+/**
+ * build-site-stitch — Generates a static website via Google Stitch MCP.
+ *
+ * Unlike build-site (which uses template-based code generation), this script
+ * sends each page through the Stitch AI design pipeline and assembles the
+ * resulting HTML into a deployable site.
+ *
+ * Steps:
+ *   1. Read output/blueprint/website-blueprint.v1.json (or --blueprint path)
+ *   2. Create a Stitch project for this business
+ *   3. Generate one AI screen per blueprint page (uses STITCH_MODEL, default: GEMINI_3_PRO)
+ *   4. Call build_site — maps all screens to routes, returns full HTML per page
+ *   5. Post-process — inject SEO meta tags, JSON-LD, skip link, lang attribute
+ *   6. Write output/stitch-site/{route}/index.html for every page
+ *
+ * Requirements:
+ *   STITCH_API_KEY must be set in .env or the environment.
+ *
+ * Usage:
+ *   npm run build:site:stitch
+ *   npm run build:site:stitch -- --blueprint path/to/blueprint.json
+ *   STITCH_MODEL=GEMINI_3_FLASH npm run build:site:stitch
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { generateWithStitch } from "../framework/core/stitch-generator.js";
+import type { WebsiteBlueprint } from "../framework/schemas/blueprint.types.js";
+
+// Load .env if present (Node 18 does not auto-load .env)
+loadDotEnv(path.resolve(".env"));
+
+const args = process.argv.slice(2);
+const getBlueprintPath = (): string => {
+  const i = args.indexOf("--blueprint");
+  return i !== -1 && args[i + 1]
+    ? path.resolve(args[i + 1])
+    : path.resolve("output/blueprint/website-blueprint.v1.json");
+};
+
+const DIVIDER = "━".repeat(52);
+
+function step(n: number, total: number, label: string) {
+  console.log(`\n  [${n}/${total}] ${label}...`);
+}
+function ok(msg: string)   { console.log(`  ✓  ${msg}`); }
+function warn(msg: string) { console.warn(`  ⚠  ${msg}`); }
+function fail(msg: string) { console.error(`  ✗  ${msg}`); }
+
+async function main() {
+  console.log(`\n${DIVIDER}`);
+  console.log("  Stitchfy v2 — Build with Google Stitch");
+  console.log(DIVIDER);
+
+  const blueprintPath = getBlueprintPath();
+  const outputDir     = path.resolve("output/stitch-site");
+  const TOTAL         = 3;
+
+  // ── Step 1: Read blueprint ──────────────────────────────────────────────────
+  step(1, TOTAL, "Reading blueprint");
+
+  if (!fs.existsSync(blueprintPath)) {
+    fail(`Blueprint not found: ${blueprintPath}`);
+    console.log('  Run "npm run stitchfy" first to generate the blueprint.\n');
+    process.exit(1);
+  }
+
+  let blueprint: WebsiteBlueprint;
+  try {
+    blueprint = JSON.parse(fs.readFileSync(blueprintPath, "utf-8")) as WebsiteBlueprint;
+  } catch (e) {
+    fail(`Failed to parse blueprint: ${(e as Error).message}`);
+    process.exit(1);
+  }
+
+  ok(
+    `Blueprint loaded — ${blueprint.pages.length} pages` +
+    ` | ${blueprint.business.name} | ${blueprint.business.industry}`
+  );
+  console.log(`  Output: ${outputDir}`);
+  console.log(`  Model:  ${process.env.STITCH_MODEL ?? "GEMINI_3_PRO"}`);
+
+  if (!process.env.STITCH_API_KEY) {
+    fail("STITCH_API_KEY is not set.");
+    console.log("  Add  STITCH_API_KEY=<your-key>  to your .env file and retry.\n");
+    process.exit(1);
+  }
+
+  // ── Step 2: Generate with Stitch ────────────────────────────────────────────
+  step(2, TOTAL, `Generating ${blueprint.pages.length} page(s) via Stitch MCP`);
+  console.log("  (Each page goes through Gemini — this may take 30–90 seconds per page)\n");
+
+  const result = await generateWithStitch(
+    blueprint,
+    outputDir,
+    (msg) => console.log(`  ${msg}`)
+  );
+
+  for (const e of result.errors)   fail(e);
+  for (const w of result.warnings) warn(w);
+
+  if (!result.ok) {
+    fail("Stitch generation failed — no pages were written.");
+    process.exit(1);
+  }
+
+  ok(`${result.pagesGenerated} page(s) written to output/stitch-site/`);
+  ok(`Stitch project ID: ${result.projectId}`);
+
+  // ── Step 3: Done ────────────────────────────────────────────────────────────
+  step(3, TOTAL, "Done");
+
+  console.log(`\n${DIVIDER}`);
+  console.log("  Stitch site ready at output/stitch-site/");
+  console.log("  Open output/stitch-site/index.html to preview locally.");
+  console.log('  Run "npm run audit" to check accessibility and SEO.');
+  console.log(`${DIVIDER}\n`);
+}
+
+// ─── Minimal .env loader ──────────────────────────────────────────────────────
+// Keeps the script self-contained without requiring dotenv as a dependency.
+
+function loadDotEnv(envPath: string) {
+  if (!fs.existsSync(envPath)) return;
+  const lines = fs.readFileSync(envPath, "utf-8").split("\n");
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq === -1) continue;
+    const key = line.slice(0, eq).trim();
+    const val = line.slice(eq + 1).trim().replace(/^["']|["']$/g, "");
+    if (key && !(key in process.env)) {
+      process.env[key] = val;
+    }
+  }
+}
+
+main().catch((e) => {
+  console.error("\nFatal:", e);
+  process.exit(1);
+});


### PR DESCRIPTION
Adds Google Stitch MCP as a second code generation strategy, two post-generation review agents that auto-patch HTML before writing to disk, and a unified audit command that works across both strategies.

What changed
New: Google Stitch generator (npm run build:site:stitch)
Connects to the Google Stitch MCP server (stitch.googleapis.com/mcp) via JSON-RPC 2.0. For each blueprint page, creates a Stitch project, generates an AI-designed screen using Gemini, and fetches the resulting HTML. The generator handles the full lifecycle: project creation, per-page screen generation, htmlCode download URL resolution, and retry logic for async HTML export.

New: SEO + Accessibility review agents
Two agents run on every Stitch-generated page before it is written to disk — no second Stitch call, purely deterministic HTML patching:

stitch-seo.agent — rewrites JSON-LD with correct @type (e.g. BeautySalon), fixes opening hours to Schema.org 24hr format with individual days, flags dead links Stitch invents, flags missing og:image and blueprint-text meta descriptions
stitch-a11y.agent — converts data-alt → alt on all images, adds aria-label to unlabelled <nav> and icon-only buttons, replaces focus:outline-none with a visible focus ring, adds role="img" to star rating groups, marks decorative material icons aria-hidden
All patches are attribute-level only — no structural changes to Stitch's output.

New: Unified audit command
`npm run audit now accepts --dir [static|stitch|both]. Reports are namespaced (stitch-accessibility-report.html etc.) and land in the same output/reports/ folder. build:site:stitch automatically runs the Stitch audit as its final step. --no-audit skips it.`

Updated: README → v2.1.0, CLAUDE.md
Full documentation of both strategies, pipeline diagrams, agent descriptions, environment variables, and the two-layer audit picture.

New commands

```
npm run build:site:stitch          # Stitch pipeline + inline agents + audit (all-in-one)
npm run build:site:stitch -- --no-audit   # skip audit step
npm run audit -- --dir stitch      # shorthand: npm run audit:stitch
npm run audit -- --dir both        # audit both outputs in one pass
```
New files (13)
`stitch-client.ts, stitch-prompt-builder.ts, stitch-post-processor.ts, stitch-generator.ts, stitch-patcher.ts, stitch-review-reporter.ts, stitch-html-review.types.ts, stitch-seo.agent.ts, stitch-a11y.agent.ts, build-site-stitch.ts, CLAUDE.md`

Modified files (4)
`audit-site.ts, report-generator.ts, package.json, README.md`