### PR TITLE
updates readme and makes clear the Google stitch mode creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,17 @@ npm install
 cp examples/beauty-salon.md input/project.md
 # (edit input/project.md with the real business details)
 
-# 3. Generate the blueprint
+# 3. Generate the blueprint — no API key required
+#    The five blueprint agents run deterministically by default.
+#    An OpenAI key is optional and only needed if you replace the
+#    deterministic logic with the AI calls (see OpenAI Integration below).
 npm run stitchfy
 
 # 4a. Generate website — template-based (no API key required)
 npm run build:site
 
-# 4b. Generate website — AI-designed via Google Stitch (requires STITCH_API_KEY)
+# 4b. Generate website — AI-designed via Google Stitch (only STITCH_API_KEY required)
+#    No OpenAI key needed for this path.
 npm run build:site:stitch
 
 # 5. Audit accessibility and SEO
@@ -60,6 +64,11 @@ npm run audit
 ```
 
 Open `output/static-site/index.html` (template) or `output/stitch-site/index.html` (Stitch) in any browser.
+
+> **Which generator should I use?**
+> - **No API key?** Use `npm run build:site` (template-based, always works).
+> - **Have a `STITCH_API_KEY`?** Use `npm run build:site:stitch` for AI-generated layouts — no OpenAI key needed.
+> - **Have an `OPENAI_API_KEY`?** See the [OpenAI Integration](#openai-integration) section — this enables AI-driven blueprints, not a different site generator.
 
 ---
 
@@ -258,6 +267,8 @@ Stitchfy integrates with [Google Stitch](https://stitch.google.com) as an altern
 
 ### Setup
 
+`STITCH_API_KEY` is the **only** API key required for this flow. The blueprint pipeline (`npm run stitchfy`) runs deterministically with no AI calls, so no OpenAI key is needed.
+
 ```bash
 # Add to your .env file
 STITCH_API_KEY=your-key-here
@@ -320,6 +331,8 @@ All patches are **attribute-level only** — no structural changes, no content e
 ---
 
 ## OpenAI Integration
+
+> **Scope:** OpenAI is only used for the **blueprint pipeline** (the five agents that produce `website-blueprint.v1.json`). It has no role in the template generator or the Google Stitch generator. You do not need an OpenAI key to generate a website via either generator.
 
 All five blueprint agents are structured to support an OpenAI API call but run **fully deterministically** in the default mode — no API key required. The integration point is marked in each agent file:
 

--- a/output/reports/stitch-accessibility-report.html
+++ b/output/reports/stitch-accessibility-report.html
@@ -1,0 +1,698 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Accessibility Report — Glow &amp; Go Beauty Bar</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; }
+    body { font-family: system-ui, -apple-system, sans-serif; margin: 0; color: #1a1a1a; background: #f8f8f6; line-height: 1.55; font-size: 15px; }
+    .report-header { background: #2c2c2c; color: #fff; padding: 2rem 2.5rem; }
+    .report-header h1 { font-size: 1.75rem; margin-bottom: 0.25rem; }
+    .report-header .business { font-size: 1.1rem; opacity: 0.75; margin-bottom: 1rem; }
+    .report-header .meta { font-size: 0.8rem; opacity: 0.5; display: flex; gap: 2rem; flex-wrap: wrap; }
+    main { max-width: 1100px; margin: 0 auto; padding: 2rem 2.5rem; }
+    h2 { font-size: 1.2rem; margin: 2.5rem 0 0.75rem; border-bottom: 2px solid #eee; padding-bottom: 0.4rem; color: #2c2c2c; }
+    table { width: 100%; border-collapse: collapse; margin-bottom: 1.5rem; font-size: 0.875rem; }
+    th { background: #2c2c2c; color: #fff; padding: 0.6rem 0.75rem; text-align: left; font-weight: 600; }
+    td { padding: 0.5rem 0.75rem; border-bottom: 1px solid #eee; vertical-align: top; }
+    tr:nth-child(even) td { background: #fafafa; }
+    code { font-family: monospace; background: #f0f0f0; padding: 0.1em 0.3em; border-radius: 3px; font-size: 0.85em; }
+    ul, ol { padding-left: 1.5rem; margin-bottom: 1rem; }
+    li { margin-bottom: 0.4rem; line-height: 1.5; }
+    .cards { display: flex; flex-wrap: wrap; gap: 1rem; margin: 1rem 0 2rem; }
+    .card { background: #fff; border: 1px solid #e5e5e5; border-radius: 8px; padding: 1rem 1.5rem; min-width: 160px; flex: 1; }
+    .card-label { font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.06em; opacity: 0.5; margin-bottom: 0.25rem; }
+    .card-value { font-size: 1.05rem; font-weight: 700; }
+    .disclaimer { background: #fff9e6; border-left: 4px solid #f0c040; padding: 1rem 1.25rem; margin: 1.5rem 0; border-radius: 0 6px 6px 0; font-size: 0.9rem; }
+    .note { font-size: 0.85rem; opacity: 0.6; font-style: italic; margin-bottom: 0.5rem; }
+    .badge { display: inline-block; padding: 0.15rem 0.5rem; border-radius: 20px; font-size: 0.75rem; font-weight: 700; color: #fff; }
+    footer { text-align: center; padding: 2rem; font-size: 0.8rem; opacity: 0.5; border-top: 1px solid #eee; margin-top: 3rem; }
+    a { color: #C4847A; }
+  </style>
+</head>
+<body>
+
+    <div class="report-header">
+  <h1>Accessibility Report</h1>
+  <p class="business">Glow &amp; Go Beauty Bar</p>
+  <div class="meta">
+    <span>Generated: Jun 21, 2026, 3:00 AM</span>
+    <span>Framework: Stitchfy v2</span>
+    <span>Blueprint: output/blueprint/website-blueprint.v1.json</span>
+  </div>
+</div>
+<main>
+
+    <div class="disclaimer">
+      <strong>Disclaimer:</strong> Stitchfy completed an automated and structured
+      accessibility-oriented review against the framework checklist. This does not
+      constitute legal certification. ADA compliance for any specific deployment
+      requires independent legal counsel.
+    </div>
+
+    <div class="cards">
+      <div class="card">
+    <div class="card-label">Target Standard</div>
+    <div class="card-value" style="">WCAG 2.1 Level AA</div>
+  </div>
+      <div class="card">
+    <div class="card-label">Pages Reviewed</div>
+    <div class="card-value" style="">4</div>
+  </div>
+      <div class="card">
+    <div class="card-label">Checklist Items</div>
+    <div class="card-value" style="">30</div>
+  </div>
+      <div class="card">
+    <div class="card-label">HTML Checks Passed</div>
+    <div class="card-value" style="">41</div>
+  </div>
+      <div class="card">
+    <div class="card-label">Warnings</div>
+    <div class="card-value" style="">7</div>
+  </div>
+      <div class="card">
+    <div class="card-label">Status</div>
+    <div class="card-value" style="color: #c0392b;">⚠ Review needed</div>
+  </div>
+    </div>
+
+    <h2>Framework Checklist (from blueprint)</h2>
+    <p class="note">These checks are derived from the accessibility blueprint. Static HTML checks below verify implementation.</p>
+    <table>
+      <thead><tr><th>Rule</th><th>Description</th><th>Priority</th><th>Status</th></tr></thead>
+      <tbody><tr>
+        <td><code>skip-link</code></td>
+        <td>Skip to main content link is the first focusable element on every page</td>
+        <td><span class="badge" style="background:#c0392b">must</span></td>
+        <td><span class="badge" style="background:#7f8c8d">— SKIP</span></td>
+      </tr>
+<tr>
+        <td><code>lang-attribute</code></td>
+        <td>HTML &lt;html&gt; element has a valid lang attribute (e.g., lang='en')</td>
+        <td><span class="badge" style="background:#c0392b">must</span></td>
+        <td><span class="badge" style="background:#7f8c8d">— SKIP</span></td>
+      </tr>
+<tr>
+        <td><code>page-title</code></td>
+        <td>Each page has a unique, descriptive &lt;title&gt; element</td>
+        <td><span class="badge" style="background:#c0392b">must</span></td>
+        <td><span class="badge" style="background:#7f8c8d">— SKIP</span></td>
+      </tr>
+<tr>
+        <td><code>heading-order</code></td>
+        <td>Headings are used in order (H1 → H2 → H3) — no levels skipped</td>
+        <td><span class="badge" style="background:#c0392b">must</span></td>
+        <td><span class="badge" style="background:#7f8c8d">— SKIP</span></td>
+      </tr>
+<tr>
+        <td><code>one-h1</code></td>
+        <td>Each page has exactly one H1 element</td>
+        <td><span class="badge" style="background:#c0392b">must</span></td>
+        <td><span class="badge" style="background:#7f8c8d">— SKIP</span></td>
+      </tr>
+<tr>
+        <td><code>color-contrast-normal</code></td>
+        <td>Normal text achieves a minimum 4.5:1 contrast ratio (WCAG AA)</td>
+        <td><span class="badge" style="background:#c0392b">must</span></td>
+        <td><span class="badge" style="background:#7f8c8d">— SKIP</span></td>
+      </tr>
+<tr>
+        <td><code>color-contrast-large</code></td>
+        <td>Large text (18pt+ or 14pt+ bold) achieves a minimum 3:1 contrast ratio</td>
+        <td><span class="badge" style="background:#c0392b">must</span></td>
+        <td><span class="badge" style="background:#7f8c8d">— SKIP</span></td>
+      </tr>
+<tr>
+        <td><code>image-alt-text</code></td>
+        <td>All informational images have descriptive alt text; decorative images use alt=''</td>
+        <td><span class="badge" style="background:#c0392b">must</span></td>
+        <td><span class="badge" style="background:#7f8c8d">— SKIP</span></td>
+      </tr>
+<tr>
+        <td><code>interactive-accessible</code></td>
+        <td>All interactive elements (links, buttons) are operable via keyboard</td>
+        <td><span class="badge" style="background:#c0392b">must</span></td>
+        <td><span class="badge" style="background:#7f8c8d">— SKIP</span></td>
+      </tr>
+<tr>
+        <td><code>focus-visible</code></td>
+        <td>Keyboard focus state is clearly visible — min 3px outline, not removed with outline:none</td>
+        <td><span class="badge" style="background:#c0392b">must</span></td>
+        <td><span class="badge" style="background:#7f8c8d">— SKIP</span></td>
+      </tr>
+<tr>
+        <td><code>link-purpose</code></td>
+        <td>Link text describes the destination — no 'click here' or 'read more' without context</td>
+        <td><span class="badge" style="background:#c0392b">must</span></td>
+        <td><span class="badge" style="background:#7f8c8d">— SKIP</span></td>
+      </tr>
+<tr>
+        <td><code>button-accessible-name</code></td>
+        <td>All buttons have an accessible name (text content or aria-label)</td>
+        <td><span class="badge" style="background:#c0392b">must</span></td>
+        <td><span class="badge" style="background:#7f8c8d">— SKIP</span></td>
+      </tr>
+<tr>
+        <td><code>phone-tel-link</code></td>
+        <td>Phone numbers are wrapped in &lt;a href='tel:...'&gt; for mobile users</td>
+        <td><span class="badge" style="background:#c0392b">must</span></td>
+        <td><span class="badge" style="background:#7f8c8d">— SKIP</span></td>
+      </tr>
+<tr>
+        <td><code>address-element</code></td>
+        <td>Physical addresses use the &lt;address&gt; semantic element</td>
+        <td><span class="badge" style="background:#e67e22">should</span></td>
+        <td><span class="badge" style="background:#7f8c8d">— SKIP</span></td>
+      </tr>
+<tr>
+        <td><code>landmark-banner</code></td>
+        <td>Page has a &lt;header role='banner'&gt; landmark</td>
+        <td><span class="badge" style="background:#c0392b">must</span></td>
+        <td><span class="badge" style="background:#7f8c8d">— SKIP</span></td>
+      </tr>
+<tr>
+        <td><code>landmark-navigation</code></td>
+        <td>Page has a &lt;nav aria-label='...''&gt; landmark</td>
+        <td><span class="badge" style="background:#c0392b">must</span></td>
+        <td><span class="badge" style="background:#7f8c8d">— SKIP</span></td>
+      </tr>
+<tr>
+        <td><code>landmark-main</code></td>
+        <td>Page has a &lt;main id='main-content'&gt; landmark</td>
+        <td><span class="badge" style="background:#c0392b">must</span></td>
+        <td><span class="badge" style="background:#7f8c8d">— SKIP</span></td>
+      </tr>
+<tr>
+        <td><code>landmark-contentinfo</code></td>
+        <td>Page has a &lt;footer role='contentinfo'&gt; landmark</td>
+        <td><span class="badge" style="background:#c0392b">must</span></td>
+        <td><span class="badge" style="background:#7f8c8d">— SKIP</span></td>
+      </tr>
+<tr>
+        <td><code>list-semantic</code></td>
+        <td>Navigation and service lists use &lt;ul&gt;/&lt;ol&gt; with &lt;li&gt; elements</td>
+        <td><span class="badge" style="background:#c0392b">must</span></td>
+        <td><span class="badge" style="background:#7f8c8d">— SKIP</span></td>
+      </tr>
+<tr>
+        <td><code>reduced-motion</code></td>
+        <td>@media (prefers-reduced-motion) disables or reduces all animations and transitions</td>
+        <td><span class="badge" style="background:#e67e22">should</span></td>
+        <td><span class="badge" style="background:#7f8c8d">— SKIP</span></td>
+      </tr>
+<tr>
+        <td><code>touch-target-size</code></td>
+        <td>Interactive elements are at least 44×44px on touch devices</td>
+        <td><span class="badge" style="background:#e67e22">should</span></td>
+        <td><span class="badge" style="background:#7f8c8d">— SKIP</span></td>
+      </tr>
+<tr>
+        <td><code>no-auto-play</code></td>
+        <td>No audio or video autoplays — user must initiate all media</td>
+        <td><span class="badge" style="background:#c0392b">must</span></td>
+        <td><span class="badge" style="background:#7f8c8d">— SKIP</span></td>
+      </tr>
+<tr>
+        <td><code>viewport-zoom</code></td>
+        <td>Page does not disable user pinch-zoom (no user-scalable=no in viewport meta)</td>
+        <td><span class="badge" style="background:#c0392b">must</span></td>
+        <td><span class="badge" style="background:#7f8c8d">— SKIP</span></td>
+      </tr>
+<tr>
+        <td><code>text-resize</code></td>
+        <td>Content remains accessible and readable when text is resized to 200% in browser</td>
+        <td><span class="badge" style="background:#c0392b">must</span></td>
+        <td><span class="badge" style="background:#7f8c8d">— SKIP</span></td>
+      </tr>
+<tr>
+        <td><code>form-label-visible</code></td>
+        <td>All form inputs have a visible &lt;label&gt; — not placeholder-only labels</td>
+        <td><span class="badge" style="background:#c0392b">must</span></td>
+        <td><span class="badge" style="background:#7f8c8d">— SKIP</span></td>
+      </tr>
+<tr>
+        <td><code>form-label-linked</code></td>
+        <td>Labels are linked to inputs via matching for/id or wrapping &lt;label&gt;</td>
+        <td><span class="badge" style="background:#c0392b">must</span></td>
+        <td><span class="badge" style="background:#7f8c8d">— SKIP</span></td>
+      </tr>
+<tr>
+        <td><code>form-error-message</code></td>
+        <td>Validation errors are programmatically associated with the failing field via aria-describedby</td>
+        <td><span class="badge" style="background:#c0392b">must</span></td>
+        <td><span class="badge" style="background:#7f8c8d">— SKIP</span></td>
+      </tr>
+<tr>
+        <td><code>form-required-marked</code></td>
+        <td>Required fields are marked with aria-required='true' and a visible indicator</td>
+        <td><span class="badge" style="background:#c0392b">must</span></td>
+        <td><span class="badge" style="background:#7f8c8d">— SKIP</span></td>
+      </tr>
+<tr>
+        <td><code>gallery-alt-descriptive</code></td>
+        <td>Gallery images have service-specific alt text describing the treatment and result — not file names</td>
+        <td><span class="badge" style="background:#c0392b">must</span></td>
+        <td><span class="badge" style="background:#7f8c8d">— SKIP</span></td>
+      </tr>
+<tr>
+        <td><code>gallery-filter-accessible</code></td>
+        <td>Gallery filter buttons announce their active state via aria-pressed or aria-selected</td>
+        <td><span class="badge" style="background:#c0392b">must</span></td>
+        <td><span class="badge" style="background:#7f8c8d">— SKIP</span></td>
+      </tr></tbody>
+    </table>
+
+    <h2>Static HTML Analysis </h2>
+    <table>
+      <thead><tr><th>Page</th><th>Rule</th><th>Description</th><th>Status</th><th>Detail</th></tr></thead>
+      <tbody><tr>
+          <td>Home</td>
+          <td><code>lang-attribute</code></td>
+          <td>HTML lang attribute present</td>
+          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+          <td style="opacity:0.7; font-size:0.85rem"></td>
+        </tr>
+<tr>
+          <td>Home</td>
+          <td><code>page-title</code></td>
+          <td>Page has a descriptive title</td>
+          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+          <td style="opacity:0.7; font-size:0.85rem">&quot;Glow &amp;amp; Go Beauty Bar | Beauty Salon / Blowout Bar in Miami Beach, FL&quot;</td>
+        </tr>
+<tr>
+          <td>Home</td>
+          <td><code>meta-description</code></td>
+          <td>Meta description present</td>
+          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+          <td style="opacity:0.7; font-size:0.85rem">Check that content is non-empty and ≤ 160 characters</td>
+        </tr>
+<tr>
+          <td>Home</td>
+          <td><code>one-h1</code></td>
+          <td>Page has exactly one H1</td>
+          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+          <td style="opacity:0.7; font-size:0.85rem">Found 1 H1 element</td>
+        </tr>
+<tr>
+          <td>Home</td>
+          <td><code>skip-link</code></td>
+          <td>Skip-to-content link targets #main-content</td>
+          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+          <td style="opacity:0.7; font-size:0.85rem"></td>
+        </tr>
+<tr>
+          <td>Home</td>
+          <td><code>landmark-main</code></td>
+          <td>&lt;main id='main-content'&gt; landmark present</td>
+          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+          <td style="opacity:0.7; font-size:0.85rem"></td>
+        </tr>
+<tr>
+          <td>Home</td>
+          <td><code>landmark-banner</code></td>
+          <td>&lt;header role='banner'&gt; present</td>
+          <td><span class="badge" style="background:#c0392b">✗ FAIL</span></td>
+          <td style="opacity:0.7; font-size:0.85rem"></td>
+        </tr>
+<tr>
+          <td>Home</td>
+          <td><code>landmark-contentinfo</code></td>
+          <td>&lt;footer role='contentinfo'&gt; present</td>
+          <td><span class="badge" style="background:#c0392b">✗ FAIL</span></td>
+          <td style="opacity:0.7; font-size:0.85rem"></td>
+        </tr>
+<tr>
+          <td>Home</td>
+          <td><code>landmark-navigation</code></td>
+          <td>&lt;nav&gt; has aria-label</td>
+          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+          <td style="opacity:0.7; font-size:0.85rem"></td>
+        </tr>
+<tr>
+          <td>Home</td>
+          <td><code>image-alt-text</code></td>
+          <td>All &lt;img&gt; elements have alt attributes</td>
+          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+          <td style="opacity:0.7; font-size:0.85rem"></td>
+        </tr>
+<tr>
+          <td>Home</td>
+          <td><code>phone-tel-link</code></td>
+          <td>Phone numbers wrapped in tel: links</td>
+          <td><span class="badge" style="background:#e67e22">⚠ WARN</span></td>
+          <td style="opacity:0.7; font-size:0.85rem">2 phone number(s), 0 tel: link(s)</td>
+        </tr>
+<tr>
+          <td>Home</td>
+          <td><code>address-element</code></td>
+          <td>&lt;address&gt; element used for physical address</td>
+          <td><span class="badge" style="background:#e67e22">⚠ WARN</span></td>
+          <td style="opacity:0.7; font-size:0.85rem">Use &lt;address&gt; for physical location blocks</td>
+        </tr>
+<tr>
+          <td>Home</td>
+          <td><code>focus-visible</code></td>
+          <td>Focus outline not suppressed without replacement</td>
+          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+          <td style="opacity:0.7; font-size:0.85rem"></td>
+        </tr>
+<tr>
+          <td>Home</td>
+          <td><code>canonical</code></td>
+          <td>Canonical link tag present</td>
+          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+          <td style="opacity:0.7; font-size:0.85rem"></td>
+        </tr>
+<tr>
+          <td>Services &amp; Pricing</td>
+          <td><code>lang-attribute</code></td>
+          <td>HTML lang attribute present</td>
+          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+          <td style="opacity:0.7; font-size:0.85rem"></td>
+        </tr>
+<tr>
+          <td>Services &amp; Pricing</td>
+          <td><code>page-title</code></td>
+          <td>Page has a descriptive title</td>
+          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+          <td style="opacity:0.7; font-size:0.85rem">&quot;Services &amp;amp; Pricing | Glow &amp;amp; Go Beauty Bar&quot;</td>
+        </tr>
+<tr>
+          <td>Services &amp; Pricing</td>
+          <td><code>meta-description</code></td>
+          <td>Meta description present</td>
+          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+          <td style="opacity:0.7; font-size:0.85rem">Check that content is non-empty and ≤ 160 characters</td>
+        </tr>
+<tr>
+          <td>Services &amp; Pricing</td>
+          <td><code>one-h1</code></td>
+          <td>Page has exactly one H1</td>
+          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+          <td style="opacity:0.7; font-size:0.85rem">Found 1 H1 element</td>
+        </tr>
+<tr>
+          <td>Services &amp; Pricing</td>
+          <td><code>skip-link</code></td>
+          <td>Skip-to-content link targets #main-content</td>
+          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+          <td style="opacity:0.7; font-size:0.85rem"></td>
+        </tr>
+<tr>
+          <td>Services &amp; Pricing</td>
+          <td><code>landmark-main</code></td>
+          <td>&lt;main id='main-content'&gt; landmark present</td>
+          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+          <td style="opacity:0.7; font-size:0.85rem"></td>
+        </tr>
+<tr>
+          <td>Services &amp; Pricing</td>
+          <td><code>landmark-banner</code></td>
+          <td>&lt;header role='banner'&gt; present</td>
+          <td><span class="badge" style="background:#c0392b">✗ FAIL</span></td>
+          <td style="opacity:0.7; font-size:0.85rem"></td>
+        </tr>
+<tr>
+          <td>Services &amp; Pricing</td>
+          <td><code>landmark-contentinfo</code></td>
+          <td>&lt;footer role='contentinfo'&gt; present</td>
+          <td><span class="badge" style="background:#c0392b">✗ FAIL</span></td>
+          <td style="opacity:0.7; font-size:0.85rem"></td>
+        </tr>
+<tr>
+          <td>Services &amp; Pricing</td>
+          <td><code>landmark-navigation</code></td>
+          <td>&lt;nav&gt; has aria-label</td>
+          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+          <td style="opacity:0.7; font-size:0.85rem"></td>
+        </tr>
+<tr>
+          <td>Services &amp; Pricing</td>
+          <td><code>image-alt-text</code></td>
+          <td>All &lt;img&gt; elements have alt attributes</td>
+          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+          <td style="opacity:0.7; font-size:0.85rem"></td>
+        </tr>
+<tr>
+          <td>Services &amp; Pricing</td>
+          <td><code>phone-tel-link</code></td>
+          <td>Phone numbers wrapped in tel: links</td>
+          <td><span class="badge" style="background:#e67e22">⚠ WARN</span></td>
+          <td style="opacity:0.7; font-size:0.85rem">2 phone number(s), 0 tel: link(s)</td>
+        </tr>
+<tr>
+          <td>Services &amp; Pricing</td>
+          <td><code>address-element</code></td>
+          <td>&lt;address&gt; element used for physical address</td>
+          <td><span class="badge" style="background:#e67e22">⚠ WARN</span></td>
+          <td style="opacity:0.7; font-size:0.85rem">Use &lt;address&gt; for physical location blocks</td>
+        </tr>
+<tr>
+          <td>Services &amp; Pricing</td>
+          <td><code>focus-visible</code></td>
+          <td>Focus outline not suppressed without replacement</td>
+          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+          <td style="opacity:0.7; font-size:0.85rem"></td>
+        </tr>
+<tr>
+          <td>Services &amp; Pricing</td>
+          <td><code>canonical</code></td>
+          <td>Canonical link tag present</td>
+          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+          <td style="opacity:0.7; font-size:0.85rem"></td>
+        </tr>
+<tr>
+          <td>Book Now</td>
+          <td><code>lang-attribute</code></td>
+          <td>HTML lang attribute present</td>
+          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+          <td style="opacity:0.7; font-size:0.85rem"></td>
+        </tr>
+<tr>
+          <td>Book Now</td>
+          <td><code>page-title</code></td>
+          <td>Page has a descriptive title</td>
+          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+          <td style="opacity:0.7; font-size:0.85rem">&quot;Book Now | Glow &amp;amp; Go Beauty Bar&quot;</td>
+        </tr>
+<tr>
+          <td>Book Now</td>
+          <td><code>meta-description</code></td>
+          <td>Meta description present</td>
+          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+          <td style="opacity:0.7; font-size:0.85rem">Check that content is non-empty and ≤ 160 characters</td>
+        </tr>
+<tr>
+          <td>Book Now</td>
+          <td><code>one-h1</code></td>
+          <td>Page has exactly one H1</td>
+          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+          <td style="opacity:0.7; font-size:0.85rem">Found 1 H1 element</td>
+        </tr>
+<tr>
+          <td>Book Now</td>
+          <td><code>skip-link</code></td>
+          <td>Skip-to-content link targets #main-content</td>
+          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+          <td style="opacity:0.7; font-size:0.85rem"></td>
+        </tr>
+<tr>
+          <td>Book Now</td>
+          <td><code>landmark-main</code></td>
+          <td>&lt;main id='main-content'&gt; landmark present</td>
+          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+          <td style="opacity:0.7; font-size:0.85rem"></td>
+        </tr>
+<tr>
+          <td>Book Now</td>
+          <td><code>landmark-banner</code></td>
+          <td>&lt;header role='banner'&gt; present</td>
+          <td><span class="badge" style="background:#c0392b">✗ FAIL</span></td>
+          <td style="opacity:0.7; font-size:0.85rem"></td>
+        </tr>
+<tr>
+          <td>Book Now</td>
+          <td><code>landmark-contentinfo</code></td>
+          <td>&lt;footer role='contentinfo'&gt; present</td>
+          <td><span class="badge" style="background:#c0392b">✗ FAIL</span></td>
+          <td style="opacity:0.7; font-size:0.85rem"></td>
+        </tr>
+<tr>
+          <td>Book Now</td>
+          <td><code>landmark-navigation</code></td>
+          <td>&lt;nav&gt; has aria-label</td>
+          <td><span class="badge" style="background:#e67e22">⚠ WARN</span></td>
+          <td style="opacity:0.7; font-size:0.85rem"></td>
+        </tr>
+<tr>
+          <td>Book Now</td>
+          <td><code>image-alt-text</code></td>
+          <td>All &lt;img&gt; elements have alt attributes</td>
+          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+          <td style="opacity:0.7; font-size:0.85rem"></td>
+        </tr>
+<tr>
+          <td>Book Now</td>
+          <td><code>phone-tel-link</code></td>
+          <td>Phone numbers wrapped in tel: links</td>
+          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+          <td style="opacity:0.7; font-size:0.85rem">2 phone number(s), 2 tel: link(s)</td>
+        </tr>
+<tr>
+          <td>Book Now</td>
+          <td><code>address-element</code></td>
+          <td>&lt;address&gt; element used for physical address</td>
+          <td><span class="badge" style="background:#e67e22">⚠ WARN</span></td>
+          <td style="opacity:0.7; font-size:0.85rem">Use &lt;address&gt; for physical location blocks</td>
+        </tr>
+<tr>
+          <td>Book Now</td>
+          <td><code>focus-visible</code></td>
+          <td>Focus outline not suppressed without replacement</td>
+          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+          <td style="opacity:0.7; font-size:0.85rem"></td>
+        </tr>
+<tr>
+          <td>Book Now</td>
+          <td><code>canonical</code></td>
+          <td>Canonical link tag present</td>
+          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+          <td style="opacity:0.7; font-size:0.85rem"></td>
+        </tr>
+<tr>
+          <td>Contact</td>
+          <td><code>lang-attribute</code></td>
+          <td>HTML lang attribute present</td>
+          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+          <td style="opacity:0.7; font-size:0.85rem"></td>
+        </tr>
+<tr>
+          <td>Contact</td>
+          <td><code>page-title</code></td>
+          <td>Page has a descriptive title</td>
+          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+          <td style="opacity:0.7; font-size:0.85rem">&quot;Contact | Glow &amp;amp; Go Beauty Bar&quot;</td>
+        </tr>
+<tr>
+          <td>Contact</td>
+          <td><code>meta-description</code></td>
+          <td>Meta description present</td>
+          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+          <td style="opacity:0.7; font-size:0.85rem">Check that content is non-empty and ≤ 160 characters</td>
+        </tr>
+<tr>
+          <td>Contact</td>
+          <td><code>one-h1</code></td>
+          <td>Page has exactly one H1</td>
+          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+          <td style="opacity:0.7; font-size:0.85rem">Found 1 H1 element</td>
+        </tr>
+<tr>
+          <td>Contact</td>
+          <td><code>skip-link</code></td>
+          <td>Skip-to-content link targets #main-content</td>
+          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+          <td style="opacity:0.7; font-size:0.85rem"></td>
+        </tr>
+<tr>
+          <td>Contact</td>
+          <td><code>landmark-main</code></td>
+          <td>&lt;main id='main-content'&gt; landmark present</td>
+          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+          <td style="opacity:0.7; font-size:0.85rem"></td>
+        </tr>
+<tr>
+          <td>Contact</td>
+          <td><code>landmark-banner</code></td>
+          <td>&lt;header role='banner'&gt; present</td>
+          <td><span class="badge" style="background:#c0392b">✗ FAIL</span></td>
+          <td style="opacity:0.7; font-size:0.85rem"></td>
+        </tr>
+<tr>
+          <td>Contact</td>
+          <td><code>landmark-contentinfo</code></td>
+          <td>&lt;footer role='contentinfo'&gt; present</td>
+          <td><span class="badge" style="background:#c0392b">✗ FAIL</span></td>
+          <td style="opacity:0.7; font-size:0.85rem"></td>
+        </tr>
+<tr>
+          <td>Contact</td>
+          <td><code>landmark-navigation</code></td>
+          <td>&lt;nav&gt; has aria-label</td>
+          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+          <td style="opacity:0.7; font-size:0.85rem"></td>
+        </tr>
+<tr>
+          <td>Contact</td>
+          <td><code>image-alt-text</code></td>
+          <td>All &lt;img&gt; elements have alt attributes</td>
+          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+          <td style="opacity:0.7; font-size:0.85rem"></td>
+        </tr>
+<tr>
+          <td>Contact</td>
+          <td><code>phone-tel-link</code></td>
+          <td>Phone numbers wrapped in tel: links</td>
+          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+          <td style="opacity:0.7; font-size:0.85rem">2 phone number(s), 2 tel: link(s)</td>
+        </tr>
+<tr>
+          <td>Contact</td>
+          <td><code>address-element</code></td>
+          <td>&lt;address&gt; element used for physical address</td>
+          <td><span class="badge" style="background:#e67e22">⚠ WARN</span></td>
+          <td style="opacity:0.7; font-size:0.85rem">Use &lt;address&gt; for physical location blocks</td>
+        </tr>
+<tr>
+          <td>Contact</td>
+          <td><code>focus-visible</code></td>
+          <td>Focus outline not suppressed without replacement</td>
+          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+          <td style="opacity:0.7; font-size:0.85rem"></td>
+        </tr>
+<tr>
+          <td>Contact</td>
+          <td><code>canonical</code></td>
+          <td>Canonical link tag present</td>
+          <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+          <td style="opacity:0.7; font-size:0.85rem"></td>
+        </tr></tbody>
+    </table>
+
+    <h2>Pages Reviewed</h2>
+    <table>
+      <thead><tr><th>Page</th><th>Path</th><th>Results</th></tr></thead>
+      <tbody><tr>
+          <td><a href="/">Home</a></td>
+          <td><code>/</code></td>
+          <td><span class="badge" style="background:#27ae60">✓ PASS</span> 10 &nbsp; <span class="badge" style="background:#e67e22">⚠ WARN</span> 2 &nbsp; <span class="badge" style="background:#c0392b">✗ FAIL</span> 2</td>
+        </tr>
+<tr>
+          <td><a href="/services-pricing">Services &amp; Pricing</a></td>
+          <td><code>/services-pricing</code></td>
+          <td><span class="badge" style="background:#27ae60">✓ PASS</span> 10 &nbsp; <span class="badge" style="background:#e67e22">⚠ WARN</span> 2 &nbsp; <span class="badge" style="background:#c0392b">✗ FAIL</span> 2</td>
+        </tr>
+<tr>
+          <td><a href="/book-now">Book Now</a></td>
+          <td><code>/book-now</code></td>
+          <td><span class="badge" style="background:#27ae60">✓ PASS</span> 10 &nbsp; <span class="badge" style="background:#e67e22">⚠ WARN</span> 2 &nbsp; <span class="badge" style="background:#c0392b">✗ FAIL</span> 2</td>
+        </tr>
+<tr>
+          <td><a href="/contact">Contact</a></td>
+          <td><code>/contact</code></td>
+          <td><span class="badge" style="background:#27ae60">✓ PASS</span> 11 &nbsp; <span class="badge" style="background:#e67e22">⚠ WARN</span> 1 &nbsp; <span class="badge" style="background:#c0392b">✗ FAIL</span> 2</td>
+        </tr></tbody>
+    </table>
+
+    <h2>Lighthouse</h2>
+    <p class="note">Lighthouse scores were not generated in this run. To run Lighthouse: install <code>lighthouse</code> globally, serve <code>output/static-site/</code> locally, and run <code>lighthouse http://localhost:PORT --output html</code>.</p>
+    <p>Blueprint targets: Accessibility ≥ 95, Performance ≥ 90</p>
+  
+<footer>
+  <p>Generated by Stitchfy v2 · Apache-2.0 · Devify LLC</p>
+  <p>Lighthouse scores were not generated in this run.</p>
+</footer>
+</body>
+</html>

--- a/output/reports/stitch-final-report.html
+++ b/output/reports/stitch-final-report.html
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Final Report — Glow &amp; Go Beauty Bar</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; }
+    body { font-family: system-ui, -apple-system, sans-serif; margin: 0; color: #1a1a1a; background: #f8f8f6; line-height: 1.55; font-size: 15px; }
+    .report-header { background: #2c2c2c; color: #fff; padding: 2rem 2.5rem; }
+    .report-header h1 { font-size: 1.75rem; margin-bottom: 0.25rem; }
+    .report-header .business { font-size: 1.1rem; opacity: 0.75; margin-bottom: 1rem; }
+    .report-header .meta { font-size: 0.8rem; opacity: 0.5; display: flex; gap: 2rem; flex-wrap: wrap; }
+    main { max-width: 1100px; margin: 0 auto; padding: 2rem 2.5rem; }
+    h2 { font-size: 1.2rem; margin: 2.5rem 0 0.75rem; border-bottom: 2px solid #eee; padding-bottom: 0.4rem; color: #2c2c2c; }
+    table { width: 100%; border-collapse: collapse; margin-bottom: 1.5rem; font-size: 0.875rem; }
+    th { background: #2c2c2c; color: #fff; padding: 0.6rem 0.75rem; text-align: left; font-weight: 600; }
+    td { padding: 0.5rem 0.75rem; border-bottom: 1px solid #eee; vertical-align: top; }
+    tr:nth-child(even) td { background: #fafafa; }
+    code { font-family: monospace; background: #f0f0f0; padding: 0.1em 0.3em; border-radius: 3px; font-size: 0.85em; }
+    ul, ol { padding-left: 1.5rem; margin-bottom: 1rem; }
+    li { margin-bottom: 0.4rem; line-height: 1.5; }
+    .cards { display: flex; flex-wrap: wrap; gap: 1rem; margin: 1rem 0 2rem; }
+    .card { background: #fff; border: 1px solid #e5e5e5; border-radius: 8px; padding: 1rem 1.5rem; min-width: 160px; flex: 1; }
+    .card-label { font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.06em; opacity: 0.5; margin-bottom: 0.25rem; }
+    .card-value { font-size: 1.05rem; font-weight: 700; }
+    .disclaimer { background: #fff9e6; border-left: 4px solid #f0c040; padding: 1rem 1.25rem; margin: 1.5rem 0; border-radius: 0 6px 6px 0; font-size: 0.9rem; }
+    .note { font-size: 0.85rem; opacity: 0.6; font-style: italic; margin-bottom: 0.5rem; }
+    .badge { display: inline-block; padding: 0.15rem 0.5rem; border-radius: 20px; font-size: 0.75rem; font-weight: 700; color: #fff; }
+    footer { text-align: center; padding: 2rem; font-size: 0.8rem; opacity: 0.5; border-top: 1px solid #eee; margin-top: 3rem; }
+    a { color: #C4847A; }
+  </style>
+</head>
+<body>
+
+    <div class="report-header">
+  <h1>Final Report</h1>
+  <p class="business">Glow &amp; Go Beauty Bar</p>
+  <div class="meta">
+    <span>Generated: Jun 21, 2026, 3:00 AM</span>
+    <span>Framework: Stitchfy v2</span>
+    <span>Blueprint: output/blueprint/website-blueprint.v1.json</span>
+  </div>
+</div>
+<main>
+
+    <div class="cards">
+      <div class="card">
+    <div class="card-label">Business</div>
+    <div class="card-value" style="">Glow &amp; Go Beauty Bar</div>
+  </div>
+      <div class="card">
+    <div class="card-label">Industry</div>
+    <div class="card-value" style="">Beauty Salon / Blowout Bar</div>
+  </div>
+      <div class="card">
+    <div class="card-label">Location</div>
+    <div class="card-value" style="">Miami Beach, FL</div>
+  </div>
+      <div class="card">
+    <div class="card-label">Pages Generated</div>
+    <div class="card-value" style="">4</div>
+  </div>
+      <div class="card">
+    <div class="card-label">Static Site</div>
+    <div class="card-value" style="color: #27ae60;">✓ Built</div>
+  </div>
+      <div class="card">
+    <div class="card-label">Overall Status</div>
+    <div class="card-value" style="color: #c0392b;">⚠ Review needed</div>
+  </div>
+    </div>
+
+    <h2>Pipeline Summary</h2>
+    <table>
+      <thead><tr><th>Step</th><th>Artifact</th><th>Status</th></tr></thead>
+      <tbody>
+        <tr><td>1. Blueprint</td><td><code>output/blueprint/website-blueprint.v1.json</code></td><td><span class="badge" style="background:#27ae60">✓ PASS</span> Generated</td></tr>
+        <tr><td>2. Site source</td><td><code>output/generated-site/</code></td><td><span class="badge" style="background:#27ae60">✓ PASS</span> Generated</td></tr>
+        <tr><td>3. Static output</td><td><code>output/static-site/</code></td><td><span class="badge" style="background:#27ae60">✓ PASS</span> Built</td></tr>
+        <tr><td>4. Accessibility report</td><td><code>output/reports/accessibility-report.html</code></td><td><span class="badge" style="background:#27ae60">✓ PASS</span> Generated</td></tr>
+        <tr><td>5. SEO report</td><td><code>output/reports/seo-report.html</code></td><td><span class="badge" style="background:#27ae60">✓ PASS</span> Generated</td></tr>
+      </tbody>
+    </table>
+
+    <h2>HTML Checks Summary </h2>
+    <div class="cards">
+      <div class="card">
+    <div class="card-label">Total checks</div>
+    <div class="card-value" style="">56</div>
+  </div>
+      <div class="card">
+    <div class="card-label">Passed</div>
+    <div class="card-value" style="color: #27ae60;">41</div>
+  </div>
+      <div class="card">
+    <div class="card-label">Warnings</div>
+    <div class="card-value" style="color: #e67e22;">7</div>
+  </div>
+      <div class="card">
+    <div class="card-label">Failures</div>
+    <div class="card-value" style="color: #c0392b;">8</div>
+  </div>
+    </div>
+
+    <h2>Generated Routes</h2>
+    <table>
+      <thead><tr><th>Page</th><th>Path</th><th>File</th><th>Status</th></tr></thead>
+      <tbody><tr>
+      <td>home</td>
+      <td><code>/</code></td>
+      <td><code>app/page.tsx</code></td>
+      <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+    </tr>
+<tr>
+      <td>services-pricing</td>
+      <td><code>/services-pricing</code></td>
+      <td><code>app/services-pricing/page.tsx</code></td>
+      <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+    </tr>
+<tr>
+      <td>book-now</td>
+      <td><code>/book-now</code></td>
+      <td><code>app/book-now/page.tsx</code></td>
+      <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+    </tr>
+<tr>
+      <td>contact</td>
+      <td><code>/contact</code></td>
+      <td><code>app/contact/page.tsx</code></td>
+      <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+    </tr></tbody>
+    </table>
+
+    <h2>Unsupported Features</h2>
+    <p class="note">These features were requested or referenced but are not implemented in the static MVP.</p>
+    <table>
+      <thead><tr><th>Feature</th><th>Status</th><th>Recommendation</th></tr></thead>
+      <tbody><tr><td>Real-time booking engine or availability calendar</td><td><span class="badge" style="background:#7f8c8d">— SKIP</span> Not implemented</td><td>See booking platform or future phases</td></tr>
+<tr><td>Payment processing or e-commerce checkout</td><td><span class="badge" style="background:#7f8c8d">— SKIP</span> Not implemented</td><td>See booking platform or future phases</td></tr>
+<tr><td>User accounts, registration, or authentication</td><td><span class="badge" style="background:#7f8c8d">— SKIP</span> Not implemented</td><td>See booking platform or future phases</td></tr>
+<tr><td>Database persistence or backend API routes</td><td><span class="badge" style="background:#7f8c8d">— SKIP</span> Not implemented</td><td>See booking platform or future phases</td></tr>
+<tr><td>CRM integration (Salesforce, HubSpot, etc.)</td><td><span class="badge" style="background:#7f8c8d">— SKIP</span> Not implemented</td><td>See booking platform or future phases</td></tr>
+<tr><td>HIPAA-grade forms or electronic health records</td><td><span class="badge" style="background:#7f8c8d">— SKIP</span> Not implemented</td><td>See booking platform or future phases</td></tr>
+<tr><td>Server-side rendered (SSR) or incremental static regeneration (ISR) pages</td><td><span class="badge" style="background:#7f8c8d">— SKIP</span> Not implemented</td><td>See booking platform or future phases</td></tr>
+<tr><td>Image optimization via next/image with a remote server (unoptimized: true in static export)</td><td><span class="badge" style="background:#7f8c8d">— SKIP</span> Not implemented</td><td>See booking platform or future phases</td></tr></tbody>
+    </table>
+
+    <h2>Known Limitations</h2>
+    <ul><li>Gallery filtering requires JavaScript — with JS disabled, all images are shown (graceful degradation)</li>
+<li>Booking links navigate to an external platform — no on-site confirmation or calendar</li>
+<li>Contact form is a static mailto link — no server-side processing or spam protection</li>
+<li>No real-time availability information</li>
+<li>No account creation, login, or session management</li>
+<li>No payment processing — pricing is informational only</li>
+<li>OpenGraph og:image requires a real image at /public/og-image.jpg (1200×630px) — placeholder used in dev</li></ul>
+
+    <h2>Lighthouse Targets</h2>
+    <p class="note">Lighthouse scores were not generated in this run. Scores must be collected manually after deploying the site.</p>
+    <table>
+      <thead><tr><th>Category</th><th>Target</th><th>Actual</th></tr></thead>
+      <tbody>
+        <tr><td>performance</td><td>≥ 90</td><td style="opacity:0.5">Not run</td></tr>
+<tr><td>accessibility</td><td>≥ 95</td><td style="opacity:0.5">Not run</td></tr>
+<tr><td>best-practices</td><td>≥ 90</td><td style="opacity:0.5">Not run</td></tr>
+<tr><td>seo</td><td>≥ 95</td><td style="opacity:0.5">Not run</td></tr>
+      </tbody>
+    </table>
+
+    <h2>Next Steps</h2>
+    <ol>
+      <li>Replace placeholder gallery images in <code>output/generated-site/public/images/</code> with real photos.</li>
+      <li>Update placeholder testimonials in <code>output/generated-site/site.config.ts</code> with real client reviews.</li>
+      <li>Set the real domain name in <code>output/generated-site/app/layout.tsx</code> (<code>metadataBase</code>).</li>
+      <li>Add <code>public/og-image.jpg</code> (1200×630px) for social media sharing.</li>
+      <li>Deploy <code>output/static-site/</code> to AWS S3, Netlify, Vercel, or any static host.</li>
+      <li>Run Lighthouse after deployment to verify performance and accessibility scores.</li>
+      <li>Verify all <code>tel:</code> links work on mobile devices.</li>
+    </ol>
+  
+<footer>
+  <p>Generated by Stitchfy v2 · Apache-2.0 · Devify LLC</p>
+  <p>Lighthouse scores were not generated in this run.</p>
+</footer>
+</body>
+</html>

--- a/output/reports/stitch-review-report.html
+++ b/output/reports/stitch-review-report.html
@@ -48,12 +48,12 @@
 <body>
 <div class="header">
   <h1>Stitchfy · Stitch Review Report</h1>
-  <p>Generated 6/20/2026, 6:11:29 PM · 4 page(s) reviewed</p>
+  <p>Generated 6/20/2026, 11:07:44 PM · 4 page(s) reviewed</p>
 </div>
 <div class="summary">
-  <div class="stat green"><div class="num">25</div><div class="lbl">Auto-patched</div></div>
+  <div class="stat green"><div class="num">19</div><div class="lbl">Auto-patched</div></div>
   <div class="stat red">  <div class="num">5</div>  <div class="lbl">Errors</div></div>
-  <div class="stat amber"><div class="num">5</div><div class="lbl">Warnings</div></div>
+  <div class="stat amber"><div class="num">6</div><div class="lbl">Warnings</div></div>
   <div class="stat blue"> <div class="num">4</div>   <div class="lbl">Info</div></div>
 </div>
 <div class="content">
@@ -64,8 +64,8 @@
   </div>
   <div class="page-body">
     <div class="section-label">Auto-patched (7)</div>
-    <ul class="patch-list"><li class="patch-item">JSON-LD: fix @type (BeautySalon), url, and opening hours format</li><li class="patch-item">Convert data-alt to alt on all &lt;img&gt; elements (WCAG 1.1.1)</li><li class="patch-item">Add aria-label=&quot;Main navigation&quot; to unlabelled &lt;nav&gt; (WCAG 1.3.6)</li><li class="patch-item">Add aria-label to mobile menu button (WCAG 4.1.2)</li><li class="patch-item">Add aria-hidden=&quot;true&quot; to decorative icon &quot;location_on&quot; (WCAG 1.1.1)</li><li class="patch-item">Add aria-hidden=&quot;true&quot; to decorative icon &quot;arrow_forward&quot; (WCAG 1.1.1)</li><li class="patch-item">Add aria-hidden=&quot;true&quot; to decorative icon &quot;menu&quot; (WCAG 1.1.1)</li></ul>
-    <div class="section-label">Manual review required (5)</div>
+    <ul class="patch-list"><li class="patch-item">JSON-LD: fix @type (BeautySalon), url, and opening hours format</li><li class="patch-item">Convert data-alt to alt on all &lt;img&gt; elements (WCAG 1.1.1)</li><li class="patch-item">Add aria-label=&quot;Main navigation&quot; to unlabelled &lt;nav&gt; (WCAG 1.3.6)</li><li class="patch-item">Add aria-label to mobile menu button (WCAG 4.1.2)</li><li class="patch-item">Add aria-hidden=&quot;true&quot; to decorative icon &quot;location_on&quot; (WCAG 1.1.1)</li><li class="patch-item">Add aria-hidden=&quot;true&quot; to decorative icon &quot;schedule&quot; (WCAG 1.1.1)</li><li class="patch-item">Add aria-hidden=&quot;true&quot; to decorative icon &quot;menu&quot; (WCAG 1.1.1)</li></ul>
+    <div class="section-label">Manual review required (6)</div>
     <div class="finding-item finding-error">
   <span class="badge badge-error">error</span>
   <span class="badge badge-seo">seo</span>
@@ -78,6 +78,12 @@
   <strong>SEO: meta description is internal blueprint text</strong><br>
   Meta description appears to be the page's internal purpose field: &quot;Welcome to Glow &amp;amp; Go Beauty Bar. Convert visitors to bookings; showcase bran...&quot;
   <div class="rec">→ Replace with a consumer-facing description (50–160 chars) before deploying. Update seo.pageMeta in the blueprint.</div>
+</div><div class="finding-item finding-warning">
+  <span class="badge badge-warning">warning</span>
+  <span class="badge badge-seo">seo</span>
+  <strong>SEO: dead internal links</strong><br>
+  Found 1 link(s) to routes not in the blueprint: /privacy
+  <div class="rec">→ Either add these pages to the blueprint and re-run the pipeline, or remove the links before deploying.</div>
 </div><div class="finding-item finding-warning">
   <span class="badge badge-warning">warning</span>
   <span class="badge badge-seo">seo</span>
@@ -105,8 +111,32 @@
     <span class="page-route">/services-pricing</span>
   </div>
   <div class="page-body">
-    <div class="section-label">Auto-patched (7)</div>
-    <ul class="patch-list"><li class="patch-item">Convert data-alt to alt on all &lt;img&gt; elements (WCAG 1.1.1)</li><li class="patch-item">Add aria-label=&quot;Main navigation&quot; to unlabelled &lt;nav&gt; (WCAG 1.3.6)</li><li class="patch-item">Add aria-label to mobile menu button (WCAG 4.1.2)</li><li class="patch-item">Add aria-hidden=&quot;true&quot; to decorative icon &quot;location_on&quot; (WCAG 1.1.1)</li><li class="patch-item">Add aria-hidden=&quot;true&quot; to decorative icon &quot;schedule&quot; (WCAG 1.1.1)</li><li class="patch-item">Add aria-hidden=&quot;true&quot; to decorative icon &quot;arrow_forward&quot; (WCAG 1.1.1)</li><li class="patch-item">Add aria-hidden=&quot;true&quot; to decorative icon &quot;menu&quot; (WCAG 1.1.1)</li></ul>
+    <div class="section-label">Auto-patched (1)</div>
+    <ul class="patch-list"><li class="patch-item">Add aria-label=&quot;Main navigation&quot; to unlabelled &lt;nav&gt; (WCAG 1.3.6)</li></ul>
+    <div class="section-label">Manual review required (2)</div>
+    <div class="finding-item finding-error">
+  <span class="badge badge-error">error</span>
+  <span class="badge badge-seo">seo</span>
+  <strong>SEO: og:image missing</strong><br>
+  No og:image meta tag found. Social sharing previews will have no image.
+  <div class="rec">→ Add &lt;meta property=&quot;og:image&quot; content=&quot;https://yourdomain.com/og-image.jpg&quot;&gt; in the blueprint's openGraph config.</div>
+</div><div class="finding-item finding-info">
+  <span class="badge badge-info">info</span>
+  <span class="badge badge-accessibility">accessibility</span>
+  <strong>WCAG 1.3.1: footer navigation landmark</strong><br>
+  Footer contains links but no &lt;nav&gt; landmark. Keyboard and AT users cannot jump to footer nav.
+  <div class="rec">→ Wrap footer links in &lt;nav aria-label=&quot;Footer navigation&quot;&gt;. This is a structural change — not auto-patched.</div>
+</div>
+  </div>
+</div>
+<div class="page-card">
+  <div class="page-header">
+    <span class="page-title">book-now</span>
+    <span class="page-route">/book-now</span>
+  </div>
+  <div class="page-body">
+    <div class="section-label">Auto-patched (3)</div>
+    <ul class="patch-list"><li class="patch-item">Add aria-label to mobile menu button (WCAG 4.1.2)</li><li class="patch-item">Add aria-hidden=&quot;true&quot; to decorative icon &quot;arrow_forward&quot; (WCAG 1.1.1)</li><li class="patch-item">Add aria-hidden=&quot;true&quot; to decorative icon &quot;menu&quot; (WCAG 1.1.1)</li></ul>
     <div class="section-label">Manual review required (3)</div>
     <div class="finding-item finding-error">
   <span class="badge badge-error">error</span>
@@ -131,12 +161,12 @@
 </div>
 <div class="page-card">
   <div class="page-header">
-    <span class="page-title">book-now</span>
-    <span class="page-route">/book-now</span>
+    <span class="page-title">contact</span>
+    <span class="page-route">/contact</span>
   </div>
   <div class="page-body">
-    <div class="section-label">Auto-patched (7)</div>
-    <ul class="patch-list"><li class="patch-item">Add aria-label=&quot;Main navigation&quot; to unlabelled &lt;nav&gt; (WCAG 1.3.6)</li><li class="patch-item">Add aria-label to mobile menu button (WCAG 4.1.2)</li><li class="patch-item">Add aria-hidden=&quot;true&quot; to decorative icon &quot;location_on&quot; (WCAG 1.1.1)</li><li class="patch-item">Add aria-hidden=&quot;true&quot; to decorative icon &quot;schedule&quot; (WCAG 1.1.1)</li><li class="patch-item">Add aria-hidden=&quot;true&quot; to decorative icon &quot;arrow_forward&quot; (WCAG 1.1.1)</li><li class="patch-item">Add aria-hidden=&quot;true&quot; to decorative icon &quot;phone&quot; (WCAG 1.1.1)</li><li class="patch-item">Add aria-hidden=&quot;true&quot; to decorative icon &quot;menu&quot; (WCAG 1.1.1)</li></ul>
+    <div class="section-label">Auto-patched (8)</div>
+    <ul class="patch-list"><li class="patch-item">Convert data-alt to alt on all &lt;img&gt; elements (WCAG 1.1.1)</li><li class="patch-item">Add aria-label=&quot;Main navigation&quot; to unlabelled &lt;nav&gt; (WCAG 1.3.6)</li><li class="patch-item">Add aria-label to mobile menu button (WCAG 4.1.2)</li><li class="patch-item">Add aria-hidden=&quot;true&quot; to decorative icon &quot;location_on&quot; (WCAG 1.1.1)</li><li class="patch-item">Add aria-hidden=&quot;true&quot; to decorative icon &quot;schedule&quot; (WCAG 1.1.1)</li><li class="patch-item">Add aria-hidden=&quot;true&quot; to decorative icon &quot;arrow_forward&quot; (WCAG 1.1.1)</li><li class="patch-item">Add aria-hidden=&quot;true&quot; to decorative icon &quot;open_in_new&quot; (WCAG 1.1.1)</li><li class="patch-item">Add aria-hidden=&quot;true&quot; to decorative icon &quot;menu&quot; (WCAG 1.1.1)</li></ul>
     <div class="section-label">Manual review required (4)</div>
     <div class="finding-item finding-error">
   <span class="badge badge-error">error</span>
@@ -147,39 +177,15 @@
 </div><div class="finding-item finding-warning">
   <span class="badge badge-warning">warning</span>
   <span class="badge badge-seo">seo</span>
+  <strong>SEO: dead internal links</strong><br>
+  Found 1 link(s) to routes not in the blueprint: /privacy
+  <div class="rec">→ Either add these pages to the blueprint and re-run the pipeline, or remove the links before deploying.</div>
+</div><div class="finding-item finding-warning">
+  <span class="badge badge-warning">warning</span>
+  <span class="badge badge-seo">seo</span>
   <strong>SEO: canonical URL is relative</strong><br>
   Canonical link is set to &quot;/&quot; (relative). Search engines expect an absolute URL.
   <div class="rec">→ Set openGraph.url in the blueprint (e.g. https://glowandgobar.com) before deploying.</div>
-</div><div class="finding-item finding-warning">
-  <span class="badge badge-warning">warning</span>
-  <span class="badge badge-accessibility">accessibility</span>
-  <strong>WCAG 2.4.7: focus visible</strong><br>
-  Found 3 uses of focus:outline-none. One (the menu button) is auto-patched. Others may suppress focus indicators.
-  <div class="rec">→ Search for focus:outline-none in the page and replace with focus:ring-* utilities.</div>
-</div><div class="finding-item finding-info">
-  <span class="badge badge-info">info</span>
-  <span class="badge badge-accessibility">accessibility</span>
-  <strong>WCAG 1.3.1: footer navigation landmark</strong><br>
-  Footer contains links but no &lt;nav&gt; landmark. Keyboard and AT users cannot jump to footer nav.
-  <div class="rec">→ Wrap footer links in &lt;nav aria-label=&quot;Footer navigation&quot;&gt;. This is a structural change — not auto-patched.</div>
-</div>
-  </div>
-</div>
-<div class="page-card">
-  <div class="page-header">
-    <span class="page-title">contact</span>
-    <span class="page-route">/contact</span>
-  </div>
-  <div class="page-body">
-    <div class="section-label">Auto-patched (4)</div>
-    <ul class="patch-list"><li class="patch-item">Add aria-label=&quot;Main navigation&quot; to unlabelled &lt;nav&gt; (WCAG 1.3.6)</li><li class="patch-item">Add aria-label to mobile menu button (WCAG 4.1.2)</li><li class="patch-item">Add aria-hidden=&quot;true&quot; to decorative icon &quot;location_on&quot; (WCAG 1.1.1)</li><li class="patch-item">Add aria-hidden=&quot;true&quot; to decorative icon &quot;menu&quot; (WCAG 1.1.1)</li></ul>
-    <div class="section-label">Manual review required (2)</div>
-    <div class="finding-item finding-error">
-  <span class="badge badge-error">error</span>
-  <span class="badge badge-seo">seo</span>
-  <strong>SEO: og:image missing</strong><br>
-  No og:image meta tag found. Social sharing previews will have no image.
-  <div class="rec">→ Add &lt;meta property=&quot;og:image&quot; content=&quot;https://yourdomain.com/og-image.jpg&quot;&gt; in the blueprint's openGraph config.</div>
 </div><div class="finding-item finding-info">
   <span class="badge badge-info">info</span>
   <span class="badge badge-accessibility">accessibility</span>

--- a/output/reports/stitch-seo-report.html
+++ b/output/reports/stitch-seo-report.html
@@ -1,0 +1,290 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SEO Report — Glow &amp; Go Beauty Bar</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; }
+    body { font-family: system-ui, -apple-system, sans-serif; margin: 0; color: #1a1a1a; background: #f8f8f6; line-height: 1.55; font-size: 15px; }
+    .report-header { background: #2c2c2c; color: #fff; padding: 2rem 2.5rem; }
+    .report-header h1 { font-size: 1.75rem; margin-bottom: 0.25rem; }
+    .report-header .business { font-size: 1.1rem; opacity: 0.75; margin-bottom: 1rem; }
+    .report-header .meta { font-size: 0.8rem; opacity: 0.5; display: flex; gap: 2rem; flex-wrap: wrap; }
+    main { max-width: 1100px; margin: 0 auto; padding: 2rem 2.5rem; }
+    h2 { font-size: 1.2rem; margin: 2.5rem 0 0.75rem; border-bottom: 2px solid #eee; padding-bottom: 0.4rem; color: #2c2c2c; }
+    table { width: 100%; border-collapse: collapse; margin-bottom: 1.5rem; font-size: 0.875rem; }
+    th { background: #2c2c2c; color: #fff; padding: 0.6rem 0.75rem; text-align: left; font-weight: 600; }
+    td { padding: 0.5rem 0.75rem; border-bottom: 1px solid #eee; vertical-align: top; }
+    tr:nth-child(even) td { background: #fafafa; }
+    code { font-family: monospace; background: #f0f0f0; padding: 0.1em 0.3em; border-radius: 3px; font-size: 0.85em; }
+    ul, ol { padding-left: 1.5rem; margin-bottom: 1rem; }
+    li { margin-bottom: 0.4rem; line-height: 1.5; }
+    .cards { display: flex; flex-wrap: wrap; gap: 1rem; margin: 1rem 0 2rem; }
+    .card { background: #fff; border: 1px solid #e5e5e5; border-radius: 8px; padding: 1rem 1.5rem; min-width: 160px; flex: 1; }
+    .card-label { font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.06em; opacity: 0.5; margin-bottom: 0.25rem; }
+    .card-value { font-size: 1.05rem; font-weight: 700; }
+    .disclaimer { background: #fff9e6; border-left: 4px solid #f0c040; padding: 1rem 1.25rem; margin: 1.5rem 0; border-radius: 0 6px 6px 0; font-size: 0.9rem; }
+    .note { font-size: 0.85rem; opacity: 0.6; font-style: italic; margin-bottom: 0.5rem; }
+    .badge { display: inline-block; padding: 0.15rem 0.5rem; border-radius: 20px; font-size: 0.75rem; font-weight: 700; color: #fff; }
+    footer { text-align: center; padding: 2rem; font-size: 0.8rem; opacity: 0.5; border-top: 1px solid #eee; margin-top: 3rem; }
+    a { color: #C4847A; }
+  </style>
+</head>
+<body>
+
+    <div class="report-header">
+  <h1>SEO Report</h1>
+  <p class="business">Glow &amp; Go Beauty Bar</p>
+  <div class="meta">
+    <span>Generated: Jun 21, 2026, 3:00 AM</span>
+    <span>Framework: Stitchfy v2</span>
+    <span>Blueprint: output/blueprint/website-blueprint.v1.json</span>
+  </div>
+</div>
+<main>
+
+    <div class="cards">
+      <div class="card">
+    <div class="card-label">Pages</div>
+    <div class="card-value" style="">4</div>
+  </div>
+      <div class="card">
+    <div class="card-label">Site Title</div>
+    <div class="card-value" style="">✓ Good length</div>
+  </div>
+      <div class="card">
+    <div class="card-label">JSON-LD Type</div>
+    <div class="card-value" style="">BeautySalon</div>
+  </div>
+      <div class="card">
+    <div class="card-label">Sitemap</div>
+    <div class="card-value" style="">✓ Generated</div>
+  </div>
+      <div class="card">
+    <div class="card-label">Robots.txt</div>
+    <div class="card-value" style="">✓ Generated</div>
+  </div>
+    </div>
+
+    <h2>Page Metadata</h2>
+    <table>
+      <thead><tr><th>Page</th><th>Title (30–70 chars)</th><th>Description (70–160 chars)</th></tr></thead>
+      <tbody><tr>
+      <td>home</td>
+      <td>Glow &amp; Go Beauty Bar | Beauty Salon / Blowout Bar in Miami Beach, FL <span class="badge" style="background:#27ae60">✓ PASS</span><br><small>68 chars</small></td>
+      <td>Welcome to Glow &amp; Go Beauty Bar. Convert visitors to bookings; showcase brand and top services <span class="badge" style="background:#27ae60">✓ PASS</span><br><small>94 chars</small></td>
+    </tr>
+<tr>
+      <td>services-pricing</td>
+      <td>Services &amp; Pricing | Glow &amp; Go Beauty Bar <span class="badge" style="background:#27ae60">✓ PASS</span><br><small>41 chars</small></td>
+      <td>Introduce the business and drive the primary contact/booking action <span class="badge" style="background:#e67e22">⚠ WARN</span><br><small>67 chars</small></td>
+    </tr>
+<tr>
+      <td>book-now</td>
+      <td>Book Now | Glow &amp; Go Beauty Bar <span class="badge" style="background:#27ae60">✓ PASS</span><br><small>31 chars</small></td>
+      <td>Introduce the business and drive the primary contact/booking action <span class="badge" style="background:#e67e22">⚠ WARN</span><br><small>67 chars</small></td>
+    </tr>
+<tr>
+      <td>contact</td>
+      <td>Contact | Glow &amp; Go Beauty Bar <span class="badge" style="background:#27ae60">✓ PASS</span><br><small>30 chars</small></td>
+      <td>Get in touch with Glow &amp; Go Beauty Bar. Find our address, phone, and hours. <span class="badge" style="background:#27ae60">✓ PASS</span><br><small>75 chars</small></td>
+    </tr></tbody>
+    </table>
+
+    <h2>SEO Checks (from HTML analysis)</h2>
+    <table><thead><tr><th>Page</th><th>Rule</th><th>Description</th><th>Status</th><th>Detail</th></tr></thead><tbody><tr>
+        <td>Home</td>
+        <td><code>page-title</code></td>
+        <td>Page has a descriptive title</td>
+        <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+        <td style="opacity:0.7; font-size:0.85rem">&quot;Glow &amp;amp; Go Beauty Bar | Beauty Salon / Blowout Bar in Miami Beach, FL&quot;</td>
+      </tr>
+<tr>
+        <td>Home</td>
+        <td><code>meta-description</code></td>
+        <td>Meta description present</td>
+        <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+        <td style="opacity:0.7; font-size:0.85rem">Check that content is non-empty and ≤ 160 characters</td>
+      </tr>
+<tr>
+        <td>Home</td>
+        <td><code>one-h1</code></td>
+        <td>Page has exactly one H1</td>
+        <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+        <td style="opacity:0.7; font-size:0.85rem">Found 1 H1 element</td>
+      </tr>
+<tr>
+        <td>Home</td>
+        <td><code>image-alt-text</code></td>
+        <td>All &lt;img&gt; elements have alt attributes</td>
+        <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+        <td style="opacity:0.7; font-size:0.85rem"></td>
+      </tr>
+<tr>
+        <td>Home</td>
+        <td><code>canonical</code></td>
+        <td>Canonical link tag present</td>
+        <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+        <td style="opacity:0.7; font-size:0.85rem"></td>
+      </tr>
+<tr>
+        <td>Services &amp; Pricing</td>
+        <td><code>page-title</code></td>
+        <td>Page has a descriptive title</td>
+        <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+        <td style="opacity:0.7; font-size:0.85rem">&quot;Services &amp;amp; Pricing | Glow &amp;amp; Go Beauty Bar&quot;</td>
+      </tr>
+<tr>
+        <td>Services &amp; Pricing</td>
+        <td><code>meta-description</code></td>
+        <td>Meta description present</td>
+        <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+        <td style="opacity:0.7; font-size:0.85rem">Check that content is non-empty and ≤ 160 characters</td>
+      </tr>
+<tr>
+        <td>Services &amp; Pricing</td>
+        <td><code>one-h1</code></td>
+        <td>Page has exactly one H1</td>
+        <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+        <td style="opacity:0.7; font-size:0.85rem">Found 1 H1 element</td>
+      </tr>
+<tr>
+        <td>Services &amp; Pricing</td>
+        <td><code>image-alt-text</code></td>
+        <td>All &lt;img&gt; elements have alt attributes</td>
+        <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+        <td style="opacity:0.7; font-size:0.85rem"></td>
+      </tr>
+<tr>
+        <td>Services &amp; Pricing</td>
+        <td><code>canonical</code></td>
+        <td>Canonical link tag present</td>
+        <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+        <td style="opacity:0.7; font-size:0.85rem"></td>
+      </tr>
+<tr>
+        <td>Book Now</td>
+        <td><code>page-title</code></td>
+        <td>Page has a descriptive title</td>
+        <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+        <td style="opacity:0.7; font-size:0.85rem">&quot;Book Now | Glow &amp;amp; Go Beauty Bar&quot;</td>
+      </tr>
+<tr>
+        <td>Book Now</td>
+        <td><code>meta-description</code></td>
+        <td>Meta description present</td>
+        <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+        <td style="opacity:0.7; font-size:0.85rem">Check that content is non-empty and ≤ 160 characters</td>
+      </tr>
+<tr>
+        <td>Book Now</td>
+        <td><code>one-h1</code></td>
+        <td>Page has exactly one H1</td>
+        <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+        <td style="opacity:0.7; font-size:0.85rem">Found 1 H1 element</td>
+      </tr>
+<tr>
+        <td>Book Now</td>
+        <td><code>image-alt-text</code></td>
+        <td>All &lt;img&gt; elements have alt attributes</td>
+        <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+        <td style="opacity:0.7; font-size:0.85rem"></td>
+      </tr>
+<tr>
+        <td>Book Now</td>
+        <td><code>canonical</code></td>
+        <td>Canonical link tag present</td>
+        <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+        <td style="opacity:0.7; font-size:0.85rem"></td>
+      </tr>
+<tr>
+        <td>Contact</td>
+        <td><code>page-title</code></td>
+        <td>Page has a descriptive title</td>
+        <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+        <td style="opacity:0.7; font-size:0.85rem">&quot;Contact | Glow &amp;amp; Go Beauty Bar&quot;</td>
+      </tr>
+<tr>
+        <td>Contact</td>
+        <td><code>meta-description</code></td>
+        <td>Meta description present</td>
+        <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+        <td style="opacity:0.7; font-size:0.85rem">Check that content is non-empty and ≤ 160 characters</td>
+      </tr>
+<tr>
+        <td>Contact</td>
+        <td><code>one-h1</code></td>
+        <td>Page has exactly one H1</td>
+        <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+        <td style="opacity:0.7; font-size:0.85rem">Found 1 H1 element</td>
+      </tr>
+<tr>
+        <td>Contact</td>
+        <td><code>image-alt-text</code></td>
+        <td>All &lt;img&gt; elements have alt attributes</td>
+        <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+        <td style="opacity:0.7; font-size:0.85rem"></td>
+      </tr>
+<tr>
+        <td>Contact</td>
+        <td><code>canonical</code></td>
+        <td>Canonical link tag present</td>
+        <td><span class="badge" style="background:#27ae60">✓ PASS</span></td>
+        <td style="opacity:0.7; font-size:0.85rem"></td>
+      </tr></tbody></table>
+
+    <h2>Structured Data Recommendations</h2>
+    <ul><li>Use @type: &quot;BeautySalon&quot; (extends LocalBusiness)</li>
+<li>Include: name, description, address (PostalAddress), telephone, openingHoursSpecification</li>
+<li>Include: url, image, sameAs (social profile URLs)</li>
+<li>Add @type: WebSite with SearchAction for sitelinks search box potential</li>
+<li>Add @type: BreadcrumbList on inner pages</li>
+<li>Add @type: Service for each of: Express Blowouts (45 min), Signature Blowout (60 min), Updos &amp; Event Styling</li></ul>
+
+    <h2>Local SEO Checklist</h2>
+    <ul><li>Claim and optimize Google Business Profile for &quot;Glow &amp; Go Beauty Bar&quot;</li>
+<li>NAP consistency: &quot;Glow &amp; Go Beauty Bar&quot; / &quot;800 Collins Avenue, Miami Beach, FL 33139&quot; / &quot;(305) 555-0210&quot; must be identical everywhere</li>
+<li>Create local citations on Yelp, YellowPages, and Beauty Salon / Blowout Bar-specific directories</li>
+<li>Use schema.org LocalBusiness (or sub-type) JSON-LD on every page</li>
+<li>Target geo-modified keywords: &quot;Beauty Salon / Blowout Bar in Miami Beach, FL&quot;, &quot;best beauty salon / blowout bar near me&quot;</li>
+<li>Embed Google Maps on Contact page (static iframe, no API key needed)</li>
+<li>Encourage Google reviews — display schema-compliant review markup</li></ul>
+
+    <h2>Indexability Rules</h2>
+    <table>
+      <thead><tr><th>Rule</th><th>Status</th></tr></thead>
+      <tbody><tr><td>robots.txt: allow all — no pages should be blocked for this SMB site</td><td><span class="badge" style="background:#7f8c8d">— SKIP</span></td></tr>
+<tr><td>Generate sitemap.xml at /sitemap.xml listing all pages with &lt;lastmod&gt;</td><td><span class="badge" style="background:#7f8c8d">— SKIP</span></td></tr>
+<tr><td>canonical tags on every page to prevent duplicate content</td><td><span class="badge" style="background:#7f8c8d">— SKIP</span></td></tr>
+<tr><td>No noindex tags unless specifically needed (e.g., /thank-you pages)</td><td><span class="badge" style="background:#7f8c8d">— SKIP</span></td></tr>
+<tr><td>All pages must return HTTP 200 status in the static export</td><td><span class="badge" style="background:#7f8c8d">— SKIP</span></td></tr></tbody>
+    </table>
+
+    <h2>Open Graph Tags</h2>
+    <table>
+      <thead><tr><th>Property</th><th>Value</th></tr></thead>
+      <tbody>
+        <tr><td><code>og:type</code></td><td>website</td></tr>
+<tr><td><code>og:site_name</code></td><td>Glow &amp; Go Beauty Bar</td></tr>
+<tr><td><code>og:title</code></td><td>Glow &amp; Go Beauty Bar | Beauty Salon / Blowout Bar in Miami Beach, FL</td></tr>
+<tr><td><code>og:description</code></td><td>Beauty Salon / Blowout Bar in Miami Beach, FL. Glow &amp; Go Beauty Bar offers Express Blowouts (45 min), Signature Blowout (60 min), Updos &amp; Event Styling and more</td></tr>
+<tr><td><code>og:image</code></td><td>/og-image.jpg</td></tr>
+<tr><td><code>og:image:width</code></td><td>1200</td></tr>
+<tr><td><code>og:image:height</code></td><td>630</td></tr>
+<tr><td><code>twitter:card</code></td><td>summary_large_image</td></tr>
+<tr><td><code>twitter:title</code></td><td>Glow &amp; Go Beauty Bar | Beauty Salon / Blowout Bar in Miami Beach, FL</td></tr>
+<tr><td><code>twitter:description</code></td><td>Beauty Salon / Blowout Bar in Miami Beach, FL. Glow &amp; Go Beauty Bar offers Express Blowouts (45 min), Signature Blowout (60 min), Updos &amp; Event Styling and more</td></tr>
+      </tbody>
+    </table>
+
+    <h2>Lighthouse</h2>
+    <p class="note">Lighthouse scores were not generated in this run.</p>
+    <p>Blueprint target: SEO score ≥ 95</p>
+  
+<footer>
+  <p>Generated by Stitchfy v2 · Apache-2.0 · Devify LLC</p>
+  <p>Lighthouse scores were not generated in this run.</p>
+</footer>
+</body>
+</html>

--- a/scripts/audit-site.ts
+++ b/scripts/audit-site.ts
@@ -229,7 +229,13 @@ function countFiles(dir: string): number {
   return count;
 }
 
-main().catch((e) => {
-  console.error("Fatal:", e);
-  process.exit(1);
-});
+// Only run main() when this file is the direct entry point, not when imported.
+const isDirectEntry = process.argv[1]?.endsWith("audit-site.ts") ||
+                      process.argv[1]?.endsWith("audit-site.js");
+
+if (isDirectEntry) {
+  main().catch((e) => {
+    console.error("Fatal:", e);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
docs: clarify API key requirements and generator selection in README

TL;DR: Users were unsure whether an OpenAI key was required to generate a website via Google Stitch. The README now makes it explicit that the two generators are independent choices, the blueprint pipeline is always keyless by default, and STITCH_API_KEY is the only credential needed for the Stitch flow.

Changes:

Added a "Which generator should I use?" decision callout in Quick Start mapping each scenario (no key / Stitch key / OpenAI key) to the right command
Added inline comments to Quick Start step 3 clarifying the blueprint runs deterministically with no API key
Added a one-liner to the Google Stitch Setup section stating STITCH_API_KEY is the only key needed for that flow
Added a scope callout to the OpenAI Integration section clarifying it only affects the blueprint pipeline, not the site generators